### PR TITLE
Migrate travis-ci.org to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![HTML Manuscript](https://img.shields.io/badge/manuscript-HTML-blue.svg)](https://greenelab.github.io/manubot-rootstock/)
 [![PDF Manuscript](https://img.shields.io/badge/manuscript-PDF-blue.svg)](https://greenelab.github.io/manubot-rootstock/manuscript.pdf)
-[![Build Status](https://travis-ci.org/greenelab/manubot-rootstock.svg?branch=master)](https://travis-ci.org/greenelab/manubot-rootstock)
+[![Build Status](https://travis-ci.com/greenelab/manubot-rootstock.svg?branch=master)](https://travis-ci.com/greenelab/manubot-rootstock)
 
 ## Manuscript description
 
@@ -69,7 +69,7 @@ sh build/autobuild.sh
 
 ### Continuous Integration
 
-[![Build Status](https://travis-ci.org/greenelab/manubot-rootstock.svg?branch=master)](https://travis-ci.org/greenelab/manubot-rootstock)
+[![Build Status](https://travis-ci.com/greenelab/manubot-rootstock.svg?branch=master)](https://travis-ci.com/greenelab/manubot-rootstock)
 
 Whenever a pull request is opened, Travis CI will test whether the changes break the build process to generate a formatted manuscript.
 The build process aims to detect common errors, such as invalid citations.

--- a/SETUP.md
+++ b/SETUP.md
@@ -59,7 +59,7 @@ git push --set-upstream origin output
 
 ## Continuous integration
 
-Now you must manually enable Travis CI for the new repository at https://travis-ci.org.
+Now you must manually enable Travis CI for the new repository at https://travis-ci.com.
 Click the `+` sign to "Add New Repository".
 If you don't see your repository listed, push the "Sync account" button.
 Finally, flick the repository's switch to enable CI.
@@ -87,7 +87,7 @@ Give the key a descriptive title, such as "Travis CI Manubot".
 For the next step, you need the [Travis command line client](https://github.com/travis-ci/travis.rb) installed.
 This program is a Ruby gem:
 install it with `gem install travis` (not `apt install travis`, which is a different program).
-After the install, you will need to provide your credentials to login to travis with `travis login --org`.
+After the install, you will need to provide your credentials to login to travis with `travis login`.
 
 ```sh
 travis encrypt-file \

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,6 +1,6 @@
 # Continuous integration / analysis directory
 
-[![Build Status](https://travis-ci.org/greenelab/manubot-rootstock.svg?branch=master)](https://travis-ci.org/greenelab/manubot-rootstock)
+[![Build Status](https://travis-ci.com/greenelab/manubot-rootstock.svg?branch=master)](https://travis-ci.com/greenelab/manubot-rootstock)
 
 This repository uses [continuous analysis](https://doi.org/10.1101/056473 "Reproducible Computational Workflows with Continuous Analysis") to create the manuscript and commit it back to GitHub.
 [`deploy.sh`](deploy.sh) runs on successful `master` branch builds that are not pull requests.

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -47,8 +47,8 @@ This build is based on
 https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT.
 
 This commit was created by the following Travis CI build and job:
-https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
-https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID
+https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
+https://travis-ci.com/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID
 
 [ci skip]
 


### PR DESCRIPTION
See the recent Travis blog post [Announcing support for open source projects on travis-ci.com
](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps). In short, travis-ci.org used to be for public codebases, but will be migrated to travis-ci.com in the future. New repos should use travis-ci.com:

> If you’re activating a new repository – either public or private – on Travis CI, please use travis-ci.com. You’ll be able to take advantage of our newest features, and share additional concurrency between open source and private repositories.

From [this page](https://docs.travis-ci.com/user/open-source-on-travis-ci-com/#Existing-Open-Source-Repositories-on-travis-ci.org) regarding migration of existing .org repos:

> However, open source repositories will be migrated to travis-ci.com gradually, beginning at the end of Q2 2018. You will receive an email when the migration for a repository is complete. This is an opt-in process: to have a repository migrated over, it must first be activated on travis-ci.com.

So as far as manubot-rootstock is concerned, it's a bit difficult of a situation. New Manubot instances should use .com. However, this repo hasn't received the migration email yet. Therefore, if we switch the URLs to .com, the build links won't work. So I guess my thoughts are that we should have this PR ready to go, so we can merge it after we get our migration option.