### PR TITLE
CSL style: always add space after title

### DIFF
--- a/build/assets/style.csl
+++ b/build/assets/style.csl
@@ -43,8 +43,8 @@
     </layout>
   </citation>
   <bibliography hanging-indent="true" second-field-align="margin">
-    <layout>
-      <text variable="citation-number" suffix=". "/>
+    <layout delimiter=" ">
+      <text variable="citation-number" suffix="."/>
       <group>
         <text variable="title" font-weight="bold"/>
       </group>


### PR DESCRIPTION
Fix missing space between title and rest of citation when no author present.

Closes https://github.com/greenelab/manubot-rootstock/issues/155