### PR TITLE
Update delete-me.md with full list of available formatting elements

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,3 +1,4 @@
 ## Abstract {.page_break_before}
 
-
+This manuscript is a template (aka "rootstock") for [Manubot](https://manubot.org/ "Manubot"), a tool for writing scholarly manuscripts.
+Use this template as a starting point for your manuscript by following the directions on the [repository homepage](https://github.com/manubot/rootstock "Manubot Rootstock").

--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,4 +1,1 @@
 ## Abstract {.page_break_before}
-
-This manuscript is a template (aka "rootstock") for [Manubot](https://manubot.org/ "Manubot"), a tool for writing scholarly manuscripts.
-Use this template as a starting point for your manuscript by following the directions on the [repository homepage](https://github.com/manubot/rootstock "Manubot Rootstock").

--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,1 +1,3 @@
 ## Abstract {.page_break_before}
+
+

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -146,22 +146,22 @@ Exporting PDF manuscript
 ![
 **A square image at actual size and with a bottom caption.**
 Loaded from the latest version of image on GitHub.
-](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/square.png "Square image"){#fig:square-image}
+](https://raw.githubusercontent.com/greenelab/manubot-resources/master/test/square.png "Square image"){#fig:square-image}
 
 ![
 **An image too wide to fit within page at full size.**
 Loaded from a specific (hashed) version of the image on GitHub.
-](https://github.com/manubot/resources/raw/0cec3627f989d24a636e8772acd9d458fca78b98/images/wide.png "Wide image"){#fig:wide-image}
+](https://raw.githubusercontent.com/manubot/resources/bfd6afcd9f47d7da34362e62a005d86e85aef25a/test/wide.png "Wide image"){#fig:wide-image}
 
 ![
 **A tall image with a specified height.**
 Loaded from a specific (hashed) version of the image on GitHub.
-](https://github.com/manubot/resources/raw/0cec3627f989d24a636e8772acd9d458fca78b98/images/tall.png "Tall image"){#fig:tall-image height=3in}
+](https://raw.githubusercontent.com/manubot/resources/bfd6afcd9f47d7da34362e62a005d86e85aef25a/test/tall.png "Tall image"){#fig:tall-image height=3in}
 
 ![
 **A vector `.svg` image loaded from GitHub.**
 The parameter `sanitize=true` is necessary to properly load SVGs hosted via GitHub URLs.
-](https://raw.githubusercontent.com/manubot/resources/master/images/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2.5in}
+](https://raw.githubusercontent.com/manubot/resources/master/test/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2.5in}
 
 ## Tables
 

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -1,13 +1,6 @@
-## Introduction
-
-This manuscript is a template/boilerplate (aka "rootstock") for [Manubot](https://manubot.org/ "Manubot"), a tool for writing scholarly manuscripts.
-Use this template as a starting point for your manuscript by following the directions on the [repository homepage](https://github.com/greenelab/manubot-rootstock "Manubot Rootstock").
-
-
-
 ## Examples
 
-Below is a full list of formatting elements for `.html` and `.pdf` exports that are supported by the Manubot-provided themes. 
+Below is a full list of formatting elements for `.html` and `.pdf` exports that are supported by the Manubot-provided themes.
 Compare the input Markdown (`.md` files in the `/content` directory) to the output you see below.
 
 # Heading 1
@@ -18,9 +11,9 @@ Compare the input Markdown (`.md` files in the `/content` directory) to the outp
 
 #### Heading 4
 
-##### Heading 5
+`Heading 1`'s are recommended to be reserved for the title of the manuscript
 
-###### Heading 6
+`Heading 2`'s are recommended for sections such as *Abstract*, *Methods*, *Conclusion*, etc.
 
 <!-- an arbitrary comment. not visible in output. -->
 
@@ -54,8 +47,10 @@ Combined *italics and __bold__*
 
 ~~Strikethrough~~
 
-Line break without starting new paragraph by putting  
-two spaces at end of line
+Line break without starting a new paragraph by putting  
+two spaces at end of line.
+
+Putting each sentence on its own line has numerous benefits with regard to [editing](https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line) and [version control](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
 
 1. Ordered list item
 2. Ordered list item
@@ -65,34 +60,56 @@ two spaces at end of line
 3. Ordered list item
     a. Sub-item
 
-* List item
 - List item
-+ List item
+- List item
+- List item
 
 superscript<sup>2</sup>
 
 subscript<sub>2n+1</sub>
 
-[Link](https://www.google.com)
+unicode superscript™
 
-[Link with title (hover) text](https://www.google.com "Google")
+unicode subscriptₓ
 
-[Link by reference][google homepage]
+**Links and Citations**
 
-[Google Homepage]: https://www.google.com
+Bare URL link: <https://manubot.org>
 
-[Link styled as a button](https://www.google.com "Google"){.button}
+[Link with text](https://www.manubot.org)
 
-DOI citation [@doi:10.15363/thinklab.4]
+[Link with hover text](https://www.manubot.org "Manubot Homepage")
 
-URL citation [@url:https://greenelab.github.io/meta-review]
+[Link styled as a button](https://www.manubot.org "Manubot Homepage"){.button}
 
-Citation by tag [@tag:deep-review]
+[Link by reference][manubot homepage]
 
-> Quoted text 
+[Manubot Homepage]: https://www.manubot.org
+
+Citation via DOI: [@doi:10.15363/thinklab.4]
+
+Citation by tag: [@tag:deep-review]
+
+Manual URL citation: [@url:https://greenelab.github.io/meta-review]
+
+**Figures and Tables**
+
+Figure @fig:square-image
+
+Figure @fig:wide-image
+
+Figure @fig:tall-image
+
+Figure @fig:vector-image
+
+Table @tbl:bowling-scores
+
+**Quotes and Code**
+
+> Quoted text
 
 > Quoted block of text  
-> 
+>
 > Two roads diverged in a wood, and I—  
 > I took the one less traveled by,  
 > And that has made all the difference.  
@@ -121,6 +138,8 @@ function add() {
 ![An image too wide to fit within page at full size](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/wide.png "Wide image"){#fig:wide-image}
 
 ![A tall image with a specified height](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/tall.png "Tall image"){#fig:tall-image height=3in}
+
+![A vector `.svg` image with `sanitize=true` to load from Github](https://raw.githubusercontent.com/manubot/resources/master/images/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2in}
 
 | *Bowling Scores* | Jane          | John          | Alice         | Bob           |
 |:-----------------|:-------------:|:-------------:|:-------------:|:-------------:|

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -1,15 +1,146 @@
-## Manubot Rootstock Information
+## Introduction
 
-**Note: Manubot instances should delete this file.**
+This manuscript is a template/boilerplate (aka "rootstock") for [Manubot](https://manubot.org/ "Manubot"), a tool for writing scholarly manuscripts.
+Use this template as a starting point for your manuscript by following the directions on the [repository homepage](https://github.com/greenelab/manubot-rootstock "Manubot Rootstock").
 
-The Manubot is a system for automating scholarly publishing.
-Content is written in [Pandoc Markdown](http://pandoc.org/MANUAL.html#pandocs-markdown) source files.
-See [`USAGE.md`](https://github.com/greenelab/manubot-rootstock/blob/master/USAGE.md) for more information on how to use the Manubot.
 
-The Manubot project began with the [Deep Review](https://github.com/greenelab/deep-review), where it was used to compose a highly-collaborative review article [@doi:10.1098/rsif.2017.0387].
-Another example manuscript that was created with Manubot is:
 
-+ The Sci-Hub Coverage Study ([GitHub](https://github.com/greenelab/scihub-manuscript), [HTML manuscript](https://greenelab.github.io/scihub-manuscript/)) [@doi:10.7554/eLife.32822]
+## Examples
 
-If you notice a problem with Manubot, it's best to submit an upstream fix to the appropriate repository:
-[`greenelab/manubot-rootstock`](https://github.com/greenelab/manubot-rootstock) for the git repository stub or [`greenelab/manubot`](https://github.com/greenelab/manubot) for the Python package.
+Below is a full list of formatting elements for `.html` and `.pdf` exports that are supported by the Manubot-provided themes. 
+Compare the input Markdown (`.md` files in the `/content` directory) to the output you see below.
+
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+###### Heading 6
+
+<!-- an arbitrary comment. not visible in output. -->
+
+Horizontal rule:
+
+---
+
+A long paragraph of text.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Another long paragraph.
+Donec massa sapien faucibus et molestie ac feugiat sed lectus.
+Est sit amet facilisis magna etiam.
+Ornare arcu dui vivamus arcu felis bibendum.
+Magna fermentum iaculis eu non diam.
+Vehicula ipsum a arcu cursus vitae.
+Ante metus dictum at tempor commodo ullamcorper a.
+Vitae tortor condimentum lacinia quis vel eros.
+Ut venenatis tellus in metus vulputate eu scelerisque felis imperdiet.
+Facilisis sed odio morbi quis.
+Enim ut sem viverra aliquet eget sit amet tellus.
+
+*Italic* _text_
+
+**Bold** __text__
+
+Combined *italics and __bold__*
+
+~~Strikethrough~~
+
+Line break without starting new paragraph by putting  
+two spaces at end of line
+
+1. Ordered list item
+2. Ordered list item
+    a. Sub-item
+    b. Sub-item
+        i. Sub-sub-item
+3. Ordered list item
+    a. Sub-item
+
+* List item
+- List item
++ List item
+
+superscript<sup>2</sup>
+
+subscript<sub>2n+1</sub>
+
+[Link](https://www.google.com)
+
+[Link with title (hover) text](https://www.google.com "Google")
+
+[Link by reference][google homepage]
+
+[Google Homepage]: https://www.google.com
+
+[Link styled as a button](https://www.google.com "Google"){.button}
+
+DOI citation [@doi:10.15363/thinklab.4]
+
+URL citation [@url:https://greenelab.github.io/meta-review]
+
+Citation by tag [@tag:deep-review]
+
+> Quoted text 
+
+> Quoted block of text  
+> 
+> Two roads diverged in a wood, and I—  
+> I took the one less traveled by,  
+> And that has made all the difference.  
+
+Code `in the middle` of normal text, aka `inline code`
+
+```c++
+// code block with C++ syntax highlighting
+int main() {
+    // a string too long to fit within page
+    cout << "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness";
+    return 0;
+}
+```
+
+```
+// code block with no syntax highlighting
+int count = 0;
+function add() {
+	count++;
+}
+```
+
+![A square image at actual size and with a bottom caption](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/square.png "Square image"){#fig:square-image}
+
+![An image too wide to fit within page at full size](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/wide.png "Wide image"){#fig:wide-image}
+
+![A tall image with a specified height](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/tall.png "Tall image"){#fig:tall-image height=3in}
+
+| *Bowling Scores* | Jane          | John          | Alice         | Bob           |
+|:-----------------|:-------------:|:-------------:|:-------------:|:-------------:|
+| Game 1 | 150 | 187 | 210 | 105 |
+| Game 2 |  98 | 202 | 197 | 102 |
+| Game 3 | 123 | 180 | 238 | 134 |
+
+Table: A table with a top caption and specified relative column widths {#tbl:bowling-scores}
+
+|         | Digits 1-33                        | Digits 34-66                      | Digits 67-99                      | Ref.                        |
+|:--------|:-----------------------------------|:----------------------------------|:----------------------------------|:----------------------------|
+| pi | 3.14159265358979323846264338327950 | 288419716939937510582097494459230 | 781640628620899862803482534211706 | [`piday.org`](https://www.piday.org/million/) |
+| e  | 2.71828182845904523536028747135266 | 249775724709369995957496696762772 | 407663035354759457138217852516642 | [`nasa.gov`](https://apod.nasa.gov/htmltest/gifcity/e.2mil) |
+
+Table: A table too wide to fit within page {#tbl:constant-digits}
+
+A LaTeX equation:
+
+$$\int_0^\infty e^{-x^2} dx=\frac{\sqrt{\pi}}{2}$$
+
+An equation too long to fit within page:
+
+$$x = a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r + s + t + u + v + w + x + y + z + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9$$

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -1,56 +1,20 @@
-## Examples
+This manuscript is a template (aka "rootstock") for [Manubot](https://manubot.org/ "Manubot"), a tool for writing scholarly manuscripts.
+Use this template as a starting point for your manuscript.
 
-Below is a full list of formatting elements for `.html` and `.pdf` exports that are supported by the Manubot-provided themes.
-Compare the input Markdown (`.md` files in the `/content` directory) to the output you see below.
+The rest of this document is a full list of formatting elements/features supported by Manubot.
+Compare the input (`.md` files in the `/content` directory) to the output you see below.
 
-# Heading 1
-
-## Heading 2
-
-### Heading 3
-
-#### Heading 4
-
-`Heading 1`'s are recommended to be reserved for the title of the manuscript
-
-`Heading 2`'s are recommended for sections such as *Abstract*, *Methods*, *Conclusion*, etc.
-
-<!-- an arbitrary comment. not visible in output. -->
-
-Horizontal rule:
-
----
-
-A long paragraph of text.
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Another long paragraph.
-Donec massa sapien faucibus et molestie ac feugiat sed lectus.
-Est sit amet facilisis magna etiam.
-Ornare arcu dui vivamus arcu felis bibendum.
-Magna fermentum iaculis eu non diam.
-Vehicula ipsum a arcu cursus vitae.
-Ante metus dictum at tempor commodo ullamcorper a.
-Vitae tortor condimentum lacinia quis vel eros.
-Ut venenatis tellus in metus vulputate eu scelerisque felis imperdiet.
-Facilisis sed odio morbi quis.
-Enim ut sem viverra aliquet eget sit amet tellus.
-
-*Italic* _text_
+## Basic formatting
 
 **Bold** __text__
+
+[Semi-bold text]{.semibold}
+
+*Italic* _text_
 
 Combined *italics and __bold__*
 
 ~~Strikethrough~~
-
-Line break without starting a new paragraph by putting  
-two spaces at end of line.
-
-Putting each sentence on its own line has numerous benefits with regard to [editing](https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line) and [version control](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
 
 1. Ordered list item
 2. Ordered list item
@@ -68,31 +32,69 @@ superscript<sup>2</sup>
 
 subscript<sub>2n+1</sub>
 
-unicode superscript™
+[unicode superscripts](https://www.google.com/search?q=superscript+generator)⁰¹²³⁴⁵⁶⁷⁸⁹
 
-unicode subscriptₓ
+[unicode subscripts](https://www.google.com/search?q=superscript+generator)₀₁₂₃₄₅₆₇₈₉
 
-**Links and Citations**
+A long paragraph of text.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Putting each sentence on its own line has numerous benefits with regard to [editing](https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line) and [version control](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
+
+Line break without starting a new paragraph by putting  
+two spaces at end of line.
+
+## Document organization
+
+Document section headings:
+
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+<!-- an arbitrary comment. visible in input, but not visible in output. -->
+
+Horizontal rule:
+
+---
+
+`Heading 1`'s are recommended to be reserved for the title of the manuscript.
+
+`Heading 2`'s are recommended for broad sections such as *Abstract*, *Methods*, *Conclusion*, etc.
+
+`Heading 3`'s and `Heading 4`'s are recommended for sub-sections.
+
+## Links
 
 Bare URL link: <https://manubot.org>
 
-[Link with text](https://www.manubot.org)
+[Link with text](https://manubot.org)
 
-[Link with hover text](https://www.manubot.org "Manubot Homepage")
-
-[Link styled as a button](https://www.manubot.org "Manubot Homepage"){.button}
+[Link with hover text](https://manubot.org "Manubot Homepage")
 
 [Link by reference][manubot homepage]
 
-[Manubot Homepage]: https://www.manubot.org
+[Manubot Homepage]: https://manubot.org
+
+## Citations
 
 Citation via DOI: [@doi:10.15363/thinklab.4]
 
+Citation via URL: [@url:https://github.com/manubot/rootstock]
+
 Citation by tag: [@tag:deep-review]
 
-Manual URL citation: [@url:https://greenelab.github.io/meta-review]
+Multiple citations can be put inside the same set of brackets [@doi:10.15363/thinklab.4; @tag:deep-review; @url:https://greenelab.github.io/meta-review].
+Manubot plugins provide easier, more convenient visualization of and navigation between citations [@url:https://greenelab.github.io/meta-review].
 
-**Figures and Tables**
+## Referencing figures, tables, equations
 
 Figure @fig:square-image
 
@@ -104,7 +106,11 @@ Figure @fig:vector-image
 
 Table @tbl:bowling-scores
 
-**Quotes and Code**
+Equation @eq:regular-equation
+
+Equation @eq:long-equation
+
+## Quotes and code
 
 > Quoted text
 
@@ -114,32 +120,50 @@ Table @tbl:bowling-scores
 > I took the one less traveled by,  
 > And that has made all the difference.  
 
-Code `in the middle` of normal text, aka `inline code`
+Code `in the middle` of normal text, aka `inline code`.
 
-```c++
-// code block with C++ syntax highlighting
-int main() {
-    // a string too long to fit within page
-    cout << "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness";
-    return 0;
-}
+Code block with Python syntax highlighting:
+
+```python
+from manubot.cite.doi import expand_short_doi
+
+def test_expand_short_doi():
+    doi = expand_short_doi("10/c3bp")
+    # a string too long to fit within page:
+    assert doi == "10.25313/2524-2695-2018-3-vliyanie-enhansera-copia-i-insulyatora-gypsy-na-sintez-ernk-modifikatsii-hromatina-i-svyazyvanie-insulyatornyh-belkov-vtransfetsirovannyh-geneticheskih-konstruktsiyah"
 ```
 
+Code block with no syntax highlighting:
+
 ```
-// code block with no syntax highlighting
-int count = 0;
-function add() {
-	count++;
-}
+Exporting HTML manuscript
+Exporting DOCX manuscript
+Exporting PDF manuscript
 ```
 
-![A square image at actual size and with a bottom caption](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/square.png "Square image"){#fig:square-image}
+## Figures
 
-![An image too wide to fit within page at full size](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/wide.png "Wide image"){#fig:wide-image}
+![
+**A square image at actual size and with a bottom caption.**
+Loaded from the latest version of image on GitHub.
+](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/square.png "Square image"){#fig:square-image}
 
-![A tall image with a specified height](https://raw.githubusercontent.com/greenelab/manubot-resources/master/images/tall.png "Tall image"){#fig:tall-image height=3in}
+![
+**An image too wide to fit within page at full size.**
+Loaded from a specific (hashed) version of the image on GitHub.
+](https://github.com/manubot/resources/raw/0cec3627f989d24a636e8772acd9d458fca78b98/images/wide.png "Wide image"){#fig:wide-image}
 
-![A vector `.svg` image with `sanitize=true` to load from Github](https://raw.githubusercontent.com/manubot/resources/master/images/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2in}
+![
+**A tall image with a specified height.**
+Loaded from a specific (hashed) version of the image on GitHub.
+](https://github.com/manubot/resources/raw/0cec3627f989d24a636e8772acd9d458fca78b98/images/tall.png "Tall image"){#fig:tall-image height=3in}
+
+![
+**A vector `.svg` image loaded from GitHub.**
+The parameter `sanitize=true` is necessary to properly load SVGs hosted via GitHub URLs.
+](https://raw.githubusercontent.com/manubot/resources/master/images/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2.5in}
+
+## Tables
 
 | *Bowling Scores* | Jane          | John          | Alice         | Bob           |
 |:-----------------|:-------------:|:-------------:|:-------------:|:-------------:|
@@ -147,19 +171,68 @@ function add() {
 | Game 2 |  98 | 202 | 197 | 102 |
 | Game 3 | 123 | 180 | 238 | 134 |
 
-Table: A table with a top caption and specified relative column widths {#tbl:bowling-scores}
+Table: A table with a top caption and specified relative column widths.
+{#tbl:bowling-scores}
 
 |         | Digits 1-33                        | Digits 34-66                      | Digits 67-99                      | Ref.                        |
 |:--------|:-----------------------------------|:----------------------------------|:----------------------------------|:----------------------------|
 | pi | 3.14159265358979323846264338327950 | 288419716939937510582097494459230 | 781640628620899862803482534211706 | [`piday.org`](https://www.piday.org/million/) |
 | e  | 2.71828182845904523536028747135266 | 249775724709369995957496696762772 | 407663035354759457138217852516642 | [`nasa.gov`](https://apod.nasa.gov/htmltest/gifcity/e.2mil) |
 
-Table: A table too wide to fit within page {#tbl:constant-digits}
+Table: A table too wide to fit within page.
+{#tbl:constant-digits}
+
+## Equations
 
 A LaTeX equation:
 
-$$\int_0^\infty e^{-x^2} dx=\frac{\sqrt{\pi}}{2}$$
+$$\int_0^\infty e^{-x^2} dx=\frac{\sqrt{\pi}}{2}$$ {#eq:regular-equation}
 
 An equation too long to fit within page:
 
-$$x = a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r + s + t + u + v + w + x + y + z + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9$$
+$$x = a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r + s + t + u + v + w + x + y + z + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9$$ {#eq:long-equation}
+
+## Special
+
+<i class="fas fa-exclamation-triangle"></i> [WARNING]{.semibold} _The following features are only supported and intended for `.html` and `.pdf` exports._
+_Journals are not likely to support them, and they may not display correctly when converted to other formats such as `.docx`._
+
+[Link styled as a button](https://manubot.org "Manubot Homepage"){.button}
+
+Using the [Font Awesome](https://fontawesome.com/) icon set:
+
+<!-- include the Font Awesome library, per: https://fontawesome.com/start -->
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css">
+
+<i class="fas fa-check"></i> <i class="fas fa-question"></i> <i class="fas fa-star"></i> <i class="fas fa-bell"></i> <i class="fas fa-times-circle"></i> <i class="fas fa-ellipsis-h"></i>
+
+[
+<i class="fas fa-scroll fa-lg"></i> **Light Grey Banner**<br>
+useful for *general information* - [manubot.org](https://manubot.org/)
+]{.banner .lightgrey}
+
+[
+<i class="fas fa-info-circle fa-lg"></i> **Blue Banner**<br>
+useful for *important information* - [manubot.org](https://manubot.org/)
+]{.banner .lightblue}
+
+[
+<i class="fas fa-ban fa-lg"></i> **Light Red Banner**<br>
+useful for *warnings* - [manubot.org](https://manubot.org/)
+]{.banner .lightred}
+
+Available colors for banners and text and code highlighting:  
+
+`lightgrey`{.lightgrey}
+`lightred`{.lightred}
+`lightyellow`{.lightyellow}
+`lightgreen`{.lightgreen}
+`lightblue`{.lightblue}
+`lightpurple`{.lightpurple}
+`grey`{.grey}
+`red`{.red}
+`orange`{.orange}
+`yellow`{.yellow}
+`green`{.green}
+`blue`{.blue}
+`purple`{.purple}

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -56,13 +56,15 @@ two spaces at end of line.
 
 Document section headings:
 
-# Heading 1{.center .page_center}
+# Heading 1
 
 ## Heading 2
 
 ### Heading 3
 
 #### Heading 4
+
+### A heading centered on its own printed page{.center .page_center}
 
 <!-- an arbitrary comment. visible in input, but not visible in output. -->
 

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -10,6 +10,10 @@ Compare the input (`.md` files in the `/content` directory) to the output you se
 
 [Semi-bold text]{.semibold}
 
+[Centered text]{.center}
+
+[Right-aligned text]{.right}
+
 *Italic* _text_
 
 Combined *italics and __bold__*
@@ -42,6 +46,7 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
+
 Putting each sentence on its own line has numerous benefits with regard to [editing](https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line) and [version control](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
 
 Line break without starting a new paragraph by putting  
@@ -51,7 +56,7 @@ two spaces at end of line.
 
 Document section headings:
 
-# Heading 1
+# Heading 1{.center .page_center}
 
 ## Heading 2
 
@@ -85,14 +90,22 @@ Bare URL link: <https://manubot.org>
 
 ## Citations
 
-Citation via DOI: [@doi:10.15363/thinklab.4]
+Citation by DOI [@doi:10.7554/eLife.32822].
 
-Citation via URL: [@url:https://github.com/manubot/rootstock]
+Citation by PubMed Central ID [@pmcid:PMC6103790].
 
-Citation by tag: [@tag:deep-review]
+Citation by PubMed ID [@pmid:30718888].
 
-Multiple citations can be put inside the same set of brackets [@doi:10.15363/thinklab.4; @tag:deep-review; @url:https://greenelab.github.io/meta-review].
-Manubot plugins provide easier, more convenient visualization of and navigation between citations [@url:https://greenelab.github.io/meta-review].
+Citation by Wikidata ID [@wikidata:Q56458321].
+
+Citation by ISBN [@isbn:9780262517638].
+
+Citation by URL [@url:https://github.com/manubot/rootstock].
+
+Citation by tag [@tag:deep-review].
+
+Multiple citations can be put inside the same set of brackets [@doi:10.7554/eLife.32822; @tag:deep-review; @isbn:9780262517638].
+Manubot plugins provide easier, more convenient visualization of and navigation between citations [@url:https://greenelab.github.io/meta-review; @pmid:30718888; @pmcid:PMC6103790; @tag:deep-review].
 
 ## Referencing figures, tables, equations
 
@@ -114,11 +127,13 @@ Equation @eq:long-equation
 
 > Quoted text
 
-> Quoted block of text  
+
+> Quoted block of text
 >
 > Two roads diverged in a wood, and I—  
 > I took the one less traveled by,  
-> And that has made all the difference.  
+> And that has made all the difference.
+
 
 Code `in the middle` of normal text, aka `inline code`.
 

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -161,7 +161,8 @@ Loaded from a specific (hashed) version of the image on GitHub.
 ![
 **A vector `.svg` image loaded from GitHub.**
 The parameter `sanitize=true` is necessary to properly load SVGs hosted via GitHub URLs.
-](https://raw.githubusercontent.com/manubot/resources/master/test/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2.5in}
+White background specified to serve as a backdrop for transparent sections of the image.
+](https://raw.githubusercontent.com/manubot/resources/master/test/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2.5in .white}
 
 ## Tables
 
@@ -199,6 +200,25 @@ _Journals are not likely to support them, and they may not display correctly whe
 
 [Link styled as a button](https://manubot.org "Manubot Homepage"){.button}
 
+Available background colors for text, images, code, banners, etc:  
+
+`white`{.white}
+`lightgrey`{.lightgrey}
+`grey`{.grey}
+`darkgrey`{.darkgrey}
+`black`{.black}
+`lightred`{.lightred}
+`lightyellow`{.lightyellow}
+`lightgreen`{.lightgreen}
+`lightblue`{.lightblue}
+`lightpurple`{.lightpurple}
+`red`{.red}
+`orange`{.orange}
+`yellow`{.yellow}
+`green`{.green}
+`blue`{.blue}
+`purple`{.purple}
+
 Using the [Font Awesome](https://fontawesome.com/) icon set:
 
 <!-- include the Font Awesome library, per: https://fontawesome.com/start -->
@@ -220,19 +240,3 @@ useful for *important information* - [manubot.org](https://manubot.org/)
 <i class="fas fa-ban fa-lg"></i> **Light Red Banner**<br>
 useful for *warnings* - [manubot.org](https://manubot.org/)
 ]{.banner .lightred}
-
-Available colors for banners and text and code highlighting:  
-
-`lightgrey`{.lightgrey}
-`lightred`{.lightred}
-`lightyellow`{.lightyellow}
-`lightgreen`{.lightgreen}
-`lightblue`{.lightblue}
-`lightpurple`{.lightpurple}
-`grey`{.grey}
-`red`{.red}
-`orange`{.orange}
-`yellow`{.yellow}
-`green`{.green}
-`blue`{.blue}
-`purple`{.purple}

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -1,2 +1,2 @@
 tag	citation
-deep_review	doi:10.1101/142760
+deep-review	doi:10.1098/rsif.2017.0387

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -1,5 +1,5 @@
 ---
-title: "Manubot Rootstock: Manuscript Title"
+title: "Manuscript Title"
 keywords:
   - markdown
   - publishing


### PR DESCRIPTION
Updated `delete-me.md` template to include a full list of `.html` and `.pdf` formatting elements we support in our themes. This includes headings, horizontal rules, images, tables, LaTeX, etc.