### PR TITLE
CI: only deploy on push TRAVIS_EVENT_TYPE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ cache:
     - ci/cache
 after_success:
   - test $TRAVIS_BRANCH = "master" &&
-    test $TRAVIS_PULL_REQUEST = "false" &&
+    test $TRAVIS_EVENT_TYPE = "push" &&
     sh ci/deploy.sh


### PR DESCRIPTION
From [these docs](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) of Travis environment variables:

> `TRAVIS_EVENT_TYPE`: Indicates how the build was triggered. One of `push`, `pull_request`, `api`, `cron`.

Previously, `ci/deploy.sh` could be run for `push`, `api`, or `cron` builds, but not for `pull_request` builds. This PR further restricts when deployment is run to just `push` builds.

See docs for [cron](https://docs.travis-ci.com/user/cron-jobs/) and [api](https://docs.travis-ci.com/user/triggering-builds/).

I don't think we want deployment after cron builds, since we're [thinking of](https://github.com/manubot/rootstock/pull/182#issuecomment-468182518) using cron builds to periodically test that rootstock continues to work with the latest external dependencies. Perhaps clones that want to automatically regenerate manuscripts periodically with changing inputs may want to deploy on cron builds. However, I think this is niche enough that these manuscripts could edit the `.travis.yml` file.

We're not currently using `api` builds AFAIK. I think I've used them in the past to (re-)trigger builds under special circumstances. However, you can also do this from the Travis webpage GUI. So I don't think there is any harm in disabling deploying API builds at the moment.