### PR TITLE
update lightbox tooltips and toc plugins

### DIFF
--- a/build/plugins/accordion.html
+++ b/build/plugins/accordion.html
@@ -165,8 +165,8 @@
             let rect = {};
             rect.left = 0;
             rect.top = 0;
-            rect.right = window.innerWidth;
-            rect.bottom = window.innerHeight;
+            rect.right = document.documentElement.clientWidth;
+            rect.bottom = document.documentElement.clientHeight;
             let style = {};
 
             if (element instanceof HTMLElement) {

--- a/build/plugins/jump-to-first.html
+++ b/build/plugins/jump-to-first.html
@@ -177,8 +177,8 @@
             let rect = {};
             rect.left = 0;
             rect.top = 0;
-            rect.right = window.innerWidth;
-            rect.bottom = window.innerHeight;
+            rect.right = document.documentElement.clientWidth;
+            rect.bottom = document.documentElement.clientHeight;
             let style = {};
 
             if (element instanceof HTMLElement) {

--- a/build/plugins/lightbox.html
+++ b/build/plugins/lightbox.html
@@ -25,7 +25,7 @@
                 '1.25, 1.5, 1.75, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8',
             // whether to fit image to view ('fit'), display at 100% and shrink
             // if necessary ('shrink'), or always display at 100% ('100')
-            defaultZoom: 'shrink',
+            defaultZoom: 'fit',
             // whether plugin is on or not
             enabled: 'true'
         };
@@ -43,7 +43,7 @@
             const imgs = document.querySelectorAll('figure > img');
             let count = 1;
             for (const img of imgs) {
-                img.classList.add('lightbox_img');
+                img.classList.add('lightbox_document_img');
                 img.dataset.number = count;
                 img.dataset.total = imgs.length;
                 img.addEventListener('click', openLightbox);
@@ -148,8 +148,20 @@
             zoomInfoBox
         ) {
             // create copy of source <img>
-            const img = document.createElement('img');
-            img.src = sourceImg.src;
+            const img = sourceImg.cloneNode(true);
+            img.classList.remove('lightbox_document_img');
+            img.removeAttribute('id');
+            img.removeAttribute('width');
+            img.removeAttribute('height');
+            img.style.position = 'unset';
+            img.style.margin = '0';
+            img.style.padding = '0';
+            img.style.width = '';
+            img.style.height = '';
+            img.style.minWidth = '';
+            img.style.minHeight = '';
+            img.style.maxWidth = '';
+            img.style.maxHeight = '';
             img.id = 'lightbox_img';
 
             // build sorted list of unique zoomSteps, always including a 100%
@@ -485,7 +497,7 @@
 
         // get previous image in document
         function getPrevImg(img) {
-            const imgs = document.querySelectorAll('.lightbox_img');
+            const imgs = document.querySelectorAll('.lightbox_document_img');
 
             // find index of provided img
             let index;
@@ -505,7 +517,7 @@
 
         // get next image in document
         function getNextImg(img) {
-            const imgs = document.querySelectorAll('.lightbox_img');
+            const imgs = document.querySelectorAll('.lightbox_document_img');
 
             // find index of provided img
             let index;

--- a/build/plugins/link-highlight.html
+++ b/build/plugins/link-highlight.html
@@ -27,7 +27,7 @@
             // un-hovering
             clickUnhighlight: 'false',
             // whether to also highlight links that are unique
-            highlightUnique: 'false',
+            highlightUnique: 'true',
             // whether plugin is on or not
             enabled: 'true'
         };

--- a/build/plugins/table-of-contents.html
+++ b/build/plugins/table-of-contents.html
@@ -61,7 +61,9 @@
             else
                 closePanel();
 
-            // attach scroll and hash change listeners to window
+            // attach click, scroll, and hash change listeners to window
+            window.addEventListener('click', onClick);
+            window.addEventListener('touchstart', onClick);
             window.addEventListener('scroll', onScroll);
             window.addEventListener('hashchange', onScroll);
             onScroll();
@@ -76,6 +78,11 @@
             const width =
                 parseInt(page.width) || parseInt(page.maxWidth) || 816;
             return window.innerWidth < width + 320;
+        }
+
+        // when mouse is clicked anywhere in window
+        function onClick() {
+            closePanel();
         }
 
         // when window is scrolled or hash changed
@@ -154,7 +161,8 @@
             const list = document.createElement('div');
             list.id = 'toc_list';
 
-            // attach click listeners to header and button
+            // attach click listeners
+            panel.addEventListener('click', onPanelClick);
             header.addEventListener('click', onHeaderClick);
             button.addEventListener('click', onButtonClick);
 
@@ -205,10 +213,10 @@
             }
         }
 
-        // when link is clicked
-        function onLinkClick() {
-            if (isSmallScreen())
-                closePanel();
+        // when panel is clicked
+        function onPanelClick(event) {
+            // stop click from propagating to window/document and closing panel
+            event.stopPropagation();
         }
 
         // when header itself is clicked
@@ -221,6 +229,12 @@
             togglePanel();
             // stop header underneath button from also being clicked
             event.stopPropagation();
+        }
+
+        // when link is clicked
+        function onLinkClick() {
+            if (isSmallScreen())
+                closePanel();
         }
 
         // open panel if closed, close if opened

--- a/build/plugins/tooltips.html
+++ b/build/plugins/tooltips.html
@@ -23,8 +23,8 @@
             // whether user must click off to close tooltip instead of just
             // un-hovering
             clickClose: 'false',
-            // whether to keep tooltip horizontal position when clicking
-            // prev/next buttons
+            // whether to keep tooltip horizontal position when moving between
+            // prev/next occurrences
             keepHorizontal: 'true',
             // delay (in ms) between opening and closing tooltip
             delay: '100',
@@ -97,16 +97,7 @@
 
         // when link is focused (tabbed to)
         function onLinkFocus(event) {
-            // if focus change happened due to prev/next nav button click,
-            // pass that info along to openTooltip()
-            if (
-                event &&
-                event.relatedTarget &&
-                event.relatedTarget.matches('#tooltip_nav_bar > .icon_button')
-            )
-                openTooltip(this, true);
-            else
-                openTooltip(this);
+            openTooltip(this);
         }
 
         // when link is touched on touch screen
@@ -189,17 +180,12 @@
         }
 
         // open tooltip
-        function openTooltip(link, prevNextButtonClick) {
+        function openTooltip(link) {
+            // if setting is on and already-open tooltip can be found, store
+            // original x position of tooltip
             let prevX;
-            // if setting is on, tooltip opened because of prev/next buttons,
-            // and already-open tooltip can be found, store original x
-            // position of tooltip
             const prevTooltip = document.getElementById('tooltip');
-            if (
-                options.keepHorizontal === 'true' &&
-                prevNextButtonClick &&
-                prevTooltip
-            )
+            if (options.keepHorizontal === 'true' && prevTooltip)
                 prevX = getRectInPage(prevTooltip).left;
 
             // make tooltip element
@@ -219,10 +205,7 @@
 
             // position tooltip
             const position = function() {
-                if (prevX)
-                    positionTooltip(link, prevX);
-                else
-                    positionTooltip(link);
+                positionTooltip(link, prevX);
             };
             position();
 
@@ -324,8 +307,18 @@
 
         // when tooltip is unhovered
         function onTooltipUnhover(event) {
-            if (options.clickClose !== 'true')
-                closeTooltip();
+            if (options.clickClose === 'true')
+                return;
+
+            // make sure new mouse/touch/focus no longer over tooltip or any
+            // element within it
+            const tooltip = document.getElementById('tooltip');
+            if (!tooltip)
+                return;
+            if (this.contains(event.relatedTarget))
+                return;
+
+            closeTooltip();
         }
 
         // make nav bar to go betwen prev/next instances of same reference
@@ -501,8 +494,8 @@
             let rect = {};
             rect.left = 0;
             rect.top = 0;
-            rect.right = window.innerWidth;
-            rect.bottom = window.innerHeight;
+            rect.right = document.documentElement.clientWidth;
+            rect.bottom = document.documentElement.clientHeight;
             let style = {};
 
             if (element instanceof HTMLElement) {

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -105,6 +105,7 @@
     /* links */
     a {
         color: #2196f3;
+        word-break: break-all;
     }
 
     /* superscripts and subscripts */
@@ -484,7 +485,7 @@
     @media print {
         @page {
             /* suggested printing margin */
-            margin: 0.75in;
+            margin: 1in;
         }
 
         /* document and "page" elements */
@@ -710,12 +711,13 @@
             position: absolute;
             width: 50%;
             min-width: 240px;
+            max-width: 75%;
             z-index: 1;
         }
 
         /* tooltip content */
         #tooltip_content {
-            margin: 10px 0;
+            margin-bottom: 5px;
             padding: 20px;
             border-radius: 5px;
             border: solid 1px #bdbdbd;
@@ -729,13 +731,13 @@
         #tooltip_content > p,
         #tooltip_content > figure {
             margin: 0;
+            max-height: 320px;
+            overflow-y: auto;
         }
 
-        /* tooltip copy of figure captions */
-        #tooltip_content > figure > figcaption {
-            margin: 0;
-            margin-top: 20px;
-            padding: 0;
+        /* tooltip copy of <img> */
+        #tooltip_content > figure > img {
+            max-height: 260px;
         }
 
         /* navigation bar */
@@ -982,7 +984,7 @@
 
     @media only screen {
         /* regular <img> in document when hovered */
-        .lightbox_img:hover {
+        .lightbox_document_img:hover {
             cursor: pointer;
         }
 


### PR DESCRIPTION
*Lightbox*
Changed the image copy procedure (copying `<img>` in document to lightbox `<img>`) from shallow (new `<img>` with same `src`) to deep copy (copy DOM node fully with all properties/attributes/styles, except for explicitly deleted ones like `width`, `height`, `id`, etc.).

*Tooltips*
Changed dimension styles a bit. Allowed tall tooltips to scroll vertically. Decreased spacing on nav bar.

*Table of Contents*
Allowed clicking off of the panel to close it, as expected on mobile.