### PR TITLE
fix auto option in toc plugin, fix printing page margin

### DIFF
--- a/build/plugins/table-of-contents.html
+++ b/build/plugins/table-of-contents.html
@@ -77,7 +77,7 @@
             const page = window.getComputedStyle(document.body);
             const width =
                 parseInt(page.width) || parseInt(page.maxWidth) || 816;
-            return window.innerWidth < width + 320;
+            return width + 320 < window.innerWidth;
         }
 
         // when mouse is clicked anywhere in window

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -485,7 +485,7 @@
     @media print {
         @page {
             /* suggested printing margin */
-            margin: 1in;
+            margin: 0.75in;
         }
 
         /* document and "page" elements */


### PR DESCRIPTION
Fixes https://github.com/zach-hensel/low-noise-manuscript/commit/3ae5e37f79b31e06772a80a15ac00474d6d47330 and sets page margin back to `0.75in`.