### PR TITLE
change auto open/close option functionality and comments

### DIFF
--- a/build/plugins/table-of-contents.html
+++ b/build/plugins/table-of-contents.html
@@ -27,10 +27,10 @@
             charLimit: '50',
             // whether or not to show bullets next to each toc item
             bullets: 'false',
-            // whether to always start closed ('false'), always start opened
-            // ('true'), or start open when screen wide enough to fit panel
+            // whether default behavior is to be closed ('false'), open
+            // ('true'), or only open when screen wide enough to fit panel
             // ('auto')
-            startOpen: 'false',
+            open: 'false',
             // whether plugin is on or not
             enabled: 'true'
         };
@@ -52,14 +52,7 @@
             makeEntries(panel);
             document.body.insertBefore(panel, document.body.firstChild);
 
-            // start panel open/closed based on option
-            if (
-                options.startOpen === 'true' ||
-                (options.startOpen === 'auto' && isSmallScreen())
-            )
-                openPanel();
-            else
-                closePanel();
+            openOrClosePanel();
 
             // attach click, scroll, and hash change listeners to window
             window.addEventListener('click', onClick);
@@ -72,17 +65,33 @@
             document.body.classList.add('toc_body_nudge');
         }
 
-        // determine if on mobile-like device with small screen
+        // determine if screen wide enough to fit toc panel
         function isSmallScreen() {
-            const page = window.getComputedStyle(document.body);
-            const width =
-                parseInt(page.width) || parseInt(page.maxWidth) || 816;
-            return width + 320 < window.innerWidth;
+            // in default theme:
+            // 816px = 8.5in = width of "page" (<body>) element
+            // 260px = min width of toc panel (*2 for both sides of <body>)
+            return window.innerWidth < 816 + 260 * 2;
+        }
+
+        // open/close panel based on option and screen size
+        function openOrClosePanel() {
+            if (
+                options.open === 'true' ||
+                (options.open === 'auto' && !isSmallScreen())
+            )
+                openPanel();
+            else
+                closePanel();
         }
 
         // when mouse is clicked anywhere in window
         function onClick() {
-            closePanel();
+            const panel = document.getElementById('toc_panel');
+            if (!panel)
+                return;
+
+            if (panel.dataset.open === 'true')
+                openOrClosePanel();
         }
 
         // when window is scrolled or hash changed
@@ -116,6 +125,7 @@
                 if (element.id)
                     elementsWithIds.push(element);
             }
+
 
             // get first or previous element in top half of view
             for (let i = 0; i < elementsWithIds.length; i++) {
@@ -233,8 +243,7 @@
 
         // when link is clicked
         function onLinkClick() {
-            if (isSmallScreen())
-                closePanel();
+            openOrClosePanel();
         }
 
         // open panel if closed, close if opened


### PR DESCRIPTION
@zach-hensel Maybe you want to take a look at this since you caught the bug. I've changed the option name (because it applies to more than just whether the toc *starts* open or closed) and also the behavior a little bit.

I don't think we want to change the default to `'auto'` though, just to avoid cluttering the screen. Thoughts on this @dhimmel