### PR TITLE
build: common intermediate JSON for all pandoc outputs

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -26,12 +26,13 @@ echo "Exporting Pandoc JSON manuscript"
 pandoc --verbose \
   --from=markdown \
   --to=json \
+  --metadata bibliography=$BIBLIOGRAPHY_PATH \
+  --metadata csl=$CSL_PATH \
+  --metadata link-citations=true \
   --filter=pandoc-fignos \
   --filter=pandoc-eqnos \
   --filter=pandoc-tablenos \
-  --bibliography=$BIBLIOGRAPHY_PATH \
-  --csl=$CSL_PATH \
-  --metadata link-citations=true \
+  --filter=pandoc-citeproc \
   $INPUT_PATH \
   | python -m json.tool >| output/manuscript.json  # Prettify JSON
 


### PR DESCRIPTION
We use pandoc to convert from markdown to several output formats, such as HTML, DOCX, PDF, and JATS in the future. Therefore, does it make sense to streamline the pandoc pipeline to do as much of the shared conversion together by saving an intermediate Pandoc JSON abstract syntax tree?

The benefits would be more assurance that different outputs include the same processing filters. The output-specific steps would be more clearly delineated from the common processing steps. Build times may improve slightly. We will also retain the `manuscript.json` file, which could be helpful for debugging and converting to additional formats down the road.

Draft.

Refs https://github.com/jgm/pandoc/issues/3211#issuecomment-473995211:

> I don't think the output is completely deterministic, because of maps in YAML metadata.  (JSON serialization of hash maps is not deterministic.)

Todo:

- look into broken table / equation links
- upgrade pandoc
- reduce JSON indentation
