### PR TITLE
compactify print view

### DIFF
--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -67,8 +67,9 @@
         font-weight: bold;
     }
 
-    /* header and biggest heading */
+    /* biggest heading */
     h1 {
+        margin: 40px 0;
         text-align: center;
     }
 
@@ -91,6 +92,7 @@
     /* manuscript title caption text (ie "automatically generated on") */
     header + p {
         text-align: center;
+        margin-top: 10px;
     }
 
     /* -------------------------------------------------- */

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -105,7 +105,6 @@
     /* links */
     a {
         color: #2196f3;
-        word-break: break-all;
     }
 
     /* superscripts and subscripts */

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -35,8 +35,6 @@
             border: solid 1px #bdbdbd;
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
             background: #ffffff;
-            word-break: all;
-            word-break: break-word;
         }
     }
 
@@ -69,10 +67,8 @@
         font-weight: bold;
     }
 
-    /* biggest heading */
+    /* header and biggest heading */
     h1 {
-        margin-top: 40px;
-        margin-bottom: 30px;
         text-align: center;
     }
 
@@ -95,7 +91,6 @@
     /* manuscript title caption text (ie "automatically generated on") */
     header + p {
         text-align: center;
-        margin-top: 0;
     }
 
     /* -------------------------------------------------- */
@@ -224,9 +219,7 @@
         border: solid 1px #bdbdbd;
         padding: 10px;
         /* squash table if too wide for page by forcing line breaks */
-        /* put line break break anywhere in text */
-        word-break: break-all;
-        /* put line break between words. if not supported by browser, will fall back to break-all */
+        word-break: all;
         word-break: break-word;
     }
 
@@ -527,16 +520,6 @@
             font-size: 1.10em;
         }
 
-        /* paragraphs, horizontal dividers, figures, tables, code */
-        p,
-        hr,
-        figure,
-        table,
-        pre {
-            margin-top: 15px;
-            margin-bottom: 15px;
-        }
-
         /* table cells */
         th,
         td {
@@ -786,8 +769,6 @@
             border: solid 1px #bdbdbd;
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
             background: #ffffff;
-            word-break: all;
-            word-break: break-word;
         }
 
         /* tooltip copy of paragraphs and figures */

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -221,7 +221,7 @@
         border: solid 1px #bdbdbd;
         padding: 10px;
         /* squash table if too wide for page by forcing line breaks */
-        word-break: all;
+        word-break: break-all;
         word-break: break-word;
     }
 
@@ -492,7 +492,7 @@
 
         /* "page" element */
         body {
-            font-size: 11pt;
+            font-size: 11pt !important;
             line-height: 1.35;
         }
 
@@ -520,6 +520,11 @@
         /* heading 3 */
         h3 {
             font-size: 1.10em;
+        }
+
+        /* figures and tables */
+        figure, table {
+            font-size: 0.85em;
         }
 
         /* table cells */

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -485,7 +485,7 @@
     @media print {
         @page {
             /* suggested printing margin */
-            margin: 0.75in;
+            margin: 0.5in;
         }
 
         /* document and "page" elements */
@@ -494,6 +494,75 @@
             padding: 0;
             width: 100%;
             height: 100%;
+        }
+
+        /* "page" element */
+        body {
+            font-size: 11pt;
+            line-height: 1.35;
+        }
+
+        /* all headings */
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            margin: 15px 0;
+        }
+
+        /* heading 1 */
+        h1 {
+            font-size: 1.75em;
+        }
+
+        /* heading 2 */
+        h2 {
+            font-size: 1.25em;
+            margin-top: 0;
+        }
+
+        /* heading 3 */
+        h3 {
+            font-size: 1.10em;
+        }
+
+        /* paragraphs, horizontal dividers, figures, tables, code */
+        p,
+        hr,
+        figure,
+        table,
+        pre {
+            margin-top: 15px;
+            margin-bottom: 15px;
+        }
+
+        /* table cells */
+        th,
+        td {
+            padding: 5px;
+        }
+
+        /* shrink button icons */
+        button > svg,
+        a > svg {
+            transform: scale(0.85);
+        }
+
+        /* shrink font awesome icons */
+        i.fas,
+        i.fab,
+        i.far,
+        i.fal {
+            transform: scale(0.85);
+        }
+
+        /* decrease banner margins */
+        .banner {
+            margin-top: 15px;
+            margin-bottom: 15px;
+            padding: 15px;
         }
 
         /* class for centering an element vertically on its own page */
@@ -506,11 +575,6 @@
             vertical-align: middle;
             break-before: page;
             break-after: page;
-        }
-
-        /* <h2> heading */
-        h2 {
-            margin-top: 0;
         }
 
         /* always insert a page break before the element */


### PR DESCRIPTION
@dhimmel @slochower @agitter Per request (#192), I've made changes to the print CSS rules to reduce the number of pages when printing. This includes the following:

- smaller overall font size
- smaller line spacing
- smaller page margins (0.75in -> 0.5in)
- smaller heading margins
- smaller table cell padding
- smaller button icons

See the diff for more details.

Here's how it looks on the meta-review:
[meta-review.pdf](https://github.com/manubot/rootstock/files/3044822/meta-review.pdf)
