### PR TITLE
Add meta review link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Actual manuscript instances will clone this repository (see [`SETUP.md`](SETUP.m
 
 Manubot is a system for writing scholarly manuscripts via GitHub.
 Manubot automates citations and references, versions manuscripts using git, and enables collaborative writing via GitHub.
+An [overview manuscript](https://greenelab.github.io/meta-review/) presents the benefits of collaborative writing with Manubot and its unique features.
 The [rootstock repository](https://git.io/fhQH1) is a general purpose template for creating new Manubot instances, as detailed in [`SETUP.md`](SETUP.md).
 See [`USAGE.md`](USAGE.md) for documentation how to write a manuscript.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Actual manuscript instances will clone this repository (see [`SETUP.md`](SETUP.m
 
 Manubot is a system for writing scholarly manuscripts via GitHub.
 Manubot automates citations and references, versions manuscripts using git, and enables collaborative writing via GitHub.
-An [overview manuscript](https://greenelab.github.io/meta-review/) presents the benefits of collaborative writing with Manubot and its unique features.
+An [overview manuscript](https://greenelab.github.io/meta-review/ "Open collaborative writing with Manubot") presents the benefits of collaborative writing with Manubot and its unique features.
 The [rootstock repository](https://git.io/fhQH1) is a general purpose template for creating new Manubot instances, as detailed in [`SETUP.md`](SETUP.md).
 See [`USAGE.md`](USAGE.md) for documentation how to write a manuscript.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -198,9 +198,8 @@ If you are using the Manubot, feel free to submit a pull request to add your man
 To cite the Manubot project or for more information on its design and history, see `@url:https://greenelab.github.io/meta-review/`:
 
 > **Open collaborative writing with Manubot**<br>
-Daniel S. Himmelstein, David R. Slochower, Venkat S. Malladi, Casey S.
-Greene, Anthony Gitter<br>
-_Manubot Preprint_ (2018) <https://greenelab.github.io/meta-review/>
+Daniel S. Himmelstein, Vincent Rubinetti, David R. Slochower, Dongbo Hu, Venkat S. Malladi, Casey S. Greene, Anthony Gitter<br>
+_Manubot Preprint_ (2019) <https://greenelab.github.io/meta-review/>
 
 ## Acknowledgments
 


### PR DESCRIPTION
Closes #216 

I'm leaving the full citation in `USAGE.md` to help minimize confusion about what to cite in downstream manuscript instances.