### PR TITLE
Suggested CSL Style changes by Sebastian Karcher

### DIFF
--- a/build/assets/style.csl
+++ b/build/assets/style.csl
@@ -16,6 +16,11 @@
   <macro name="author">
     <names variable="author">
       <name initialize="false" initialize-with="" et-al-min="12" et-al-use-first="10" et-al-use-last="true"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="venue"/>
+      </substitute>
     </names>
   </macro>
   <macro name="venue">

--- a/build/assets/style.csl
+++ b/build/assets/style.csl
@@ -16,6 +16,7 @@
   <macro name="author">
     <names variable="author">
       <name initialize="false" initialize-with="" et-al-min="12" et-al-use-first="10" et-al-use-last="true"/>
+      <label form="long" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
         <text macro="venue"/>

--- a/build/assets/style.csl
+++ b/build/assets/style.csl
@@ -16,7 +16,6 @@
   <macro name="author">
     <names variable="author">
       <name initialize="false" initialize-with="" et-al-min="12" et-al-use-first="10" et-al-use-last="true"/>
-      <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>
         <text macro="venue"/>


### PR DESCRIPTION
This PR is based on the commit https://github.com/dhimmel/manubot-rootstock/commit/12b478389a2557aae3d1e941dd48a79cdd9507e1, which was suggested to me by @adam3smith at the FORCE 2019 conference. The original commit message is:

> Suggested by Sebastian Karcher to Daniel Himmelstein at the FORCE2018 Conference. Not yet tested.  The changes focus on dealing with the missing space when authors are missing and showing editors.

I think it is possible these changes will resolve https://github.com/manubot/rootstock/issues/218. However, I want to test them some and read more of the CSL doc to understand what they do.