### PR TITLE
Increase shared memory (--shm-size) to prevent athenapdf Docker from crashing

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -82,10 +82,10 @@ if [ "$BUILD_PDF" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
   if [ -d output/images ]; then rm -rf output/images; fi  # if images is a directory, remove it
   cp -R -L content/images output/
   docker run \
-    --shm-size="2g" \
     --rm \
-    --volume `pwd`/output:/converted/ \
-    --security-opt seccomp:unconfined \
+    --shm-size=1g \
+    --volume=`pwd`/output:/converted/ \
+    --security-opt=seccomp:unconfined \
     arachnysdocker/athenapdf:2.16.0 \
     athenapdf \
     --delay=2000 \

--- a/build/build.sh
+++ b/build/build.sh
@@ -82,6 +82,7 @@ if [ "$BUILD_PDF" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
   if [ -d output/images ]; then rm -rf output/images; fi  # if images is a directory, remove it
   cp -R -L content/images output/
   docker run \
+    --shm-size="2g" \
     --rm \
     --volume `pwd`/output:/converted/ \
     --security-opt seccomp:unconfined \


### PR DESCRIPTION
This PR is to address situations where the Electron renderer that Athena uses to produce PDFs crashes. There are at least two ways to avoid this: either by passing `--shm-size="2g"` to `docker run` or by mounting `/dev/shm`, both of which potentially work on Travis. The former has been tested on a personal repository and seems to alleviate the crashes.

Refs https://github.com/arachnys/athenapdf/issues/195