### PR TITLE
Fix `DOCKER_EXISTS` setting so it doesn't fail when docker missing.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -51,7 +51,7 @@ pandoc --verbose \
   $INPUT_PATH
 
 # Return null if docker command is missing, otherwise return path to docker
-DOCKER_EXISTS=`command -v docker`
+DOCKER_EXISTS="$(command -v docker || true)"
 
 # Create PDF output (unless BUILD_PDF environment variable equals "false")
 if [ "$BUILD_PDF" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then


### PR DESCRIPTION
Also move to recommended quoted $() instead of backticks.

Fixes manubot/rootstock#229