### PR TITLE
Add manubot version details to build readme

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -30,3 +30,6 @@ conda env create --file environment.yml
 Activate with `conda activate manubot` (assumes `conda` version of [at least](https://github.com/conda/conda/blob/9d759d8edeb86569c25f6eb82053f09581013a2a/CHANGELOG.md#440-2017-12-20) 4.4).
 The environment should successfully install on both Linux and macOS.
 However, it will fail on Windows due to the [`pango`](https://anaconda.org/conda-forge/pango) dependency.
+
+Because the build process is dependent on having the appropriate version of the `manubot` Python package, it is necessary to use the version specified in `environment.yml`.
+The latest `manubot` release on PyPI may not be compatible with the latest version of this rootstock repository.


### PR DESCRIPTION
It is not intuitive that the latest rootstock is not compatible with the latest Manubot Python package release.  This makes the dependencies more explicit.

Closes #228 (if we all agree this is sufficient to close the issue).