### PR TITLE
Travis CI: replace after_success with deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ script:
 cache:
   directories:
     - ci/cache
-after_success:
-  - test $TRAVIS_BRANCH = "master" &&
-    test $TRAVIS_EVENT_TYPE = "push" &&
-    bash -o xtrace ci/deploy.sh
+deploy:
+  provider: script
+  script: bash -o xtrace ci/deploy.sh
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: $TRAVIS_EVENT_TYPE = "push"


### PR DESCRIPTION
Failures in after_success did not cause the entire build to fail.
Now if deployment fails, the build should fail.

References:
https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on
https://docs.travis-ci.com/user/deployment/script/
https://github.com/travis-ci/travis-ci/issues/758