### PR TITLE
disable mathjax fast preview

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -60,6 +60,7 @@ pandoc --verbose \
 DOCKER_EXISTS="$(command -v docker || true)"
 
 # Create PDF output (unless BUILD_PDF environment variable equals "false")
+# If Docker is not available, use WeasyPrint to create PDF
 if [ "${BUILD_PDF:-}" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
   echo >&2 "Exporting PDF manuscript using WeasyPrint"
   if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
@@ -82,9 +83,12 @@ if [ "${BUILD_PDF:-}" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
   rm images
 fi
 
-# Create PDF output (unless BUILD_PDF environment variable equals "false")
+# If Docker is available, use athenapdf to create PDF
 if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
   echo >&2 "Exporting PDF manuscript using Docker + Athena"
+  if [ "${CI:-}" = "true" ]; then
+    echo >&2 "Continuous integration build detected. Setting athenapdf --delay=${MANUBOT_ATHENAPDF_DELAY:=5000}"
+  fi
   if [ -d output/images ]; then rm -rf output/images; fi  # if images is a directory, remove it
   cp -R -L content/images output/
   docker run \
@@ -94,7 +98,7 @@ if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
     --security-opt=seccomp:unconfined \
     arachnysdocker/athenapdf:2.16.0 \
     athenapdf \
-    --delay=5000 \
+    --delay=${MANUBOT_ATHENAPDF_DELAY:-1100} \
     manuscript.html manuscript.pdf
   rm -rf output/images
 fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -89,7 +89,8 @@ if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
   if [ "${CI:-}" = "true" ]; then
     # Incease --delay for CI builds to ensure the webpage fully renders, even when the CI server is under high load.
     # Local builds default to a shorter --delay to minimize runtime, assuming proper rendering is less crucial.
-    echo >&2 "Continuous integration build detected. Setting athenapdf --delay=${MANUBOT_ATHENAPDF_DELAY:=5000}"
+    MANUBOT_ATHENAPDF_DELAY="${MANUBOT_ATHENAPDF_DELAY:-5000}"
+    echo >&2 "Continuous integration build detected. Setting athenapdf --delay=$MANUBOT_ATHENAPDF_DELAY"
   fi
   if [ -d output/images ]; then rm -rf output/images; fi  # if images is a directory, remove it
   cp -R -L content/images output/

--- a/build/build.sh
+++ b/build/build.sh
@@ -94,7 +94,7 @@ if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
     --security-opt=seccomp:unconfined \
     arachnysdocker/athenapdf:2.16.0 \
     athenapdf \
-    --delay=2000 \
+    --delay=5000 \
     manuscript.html manuscript.pdf
   rm -rf output/images
 fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -87,6 +87,8 @@ fi
 if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
   echo >&2 "Exporting PDF manuscript using Docker + Athena"
   if [ "${CI:-}" = "true" ]; then
+    # Incease --delay for CI builds to ensure the webpage fully renders, even when the CI server is under high load.
+    # Local builds default to a shorter --delay to minimize runtime, assuming proper rendering is less crucial.
     echo >&2 "Continuous integration build detected. Setting athenapdf --delay=${MANUBOT_ATHENAPDF_DELAY:=5000}"
   fi
   if [ -d output/images ]; then rm -rf output/images; fi  # if images is a directory, remove it

--- a/build/plugins/math.html
+++ b/build/plugins/math.html
@@ -4,7 +4,8 @@
     MathJax.Hub.Config({
         "CommonHTML": { linebreaks: { automatic: true } },
         "HTML-CSS": { linebreaks: { automatic: true } },
-        "SVG": { linebreaks: { automatic: true } }
+        "SVG": { linebreaks: { automatic: true } },
+        "fast-preview": { disabled: true }
     });
 </script>
 


### PR DESCRIPTION
This PR disables MathJax's fast-preview option and increases the Athena print delay in response to #252.

Here's what it looks like now to load equations:

![record](https://user-images.githubusercontent.com/8326331/61644909-9acf3c80-ac73-11e9-952e-b784e7d9ce77.gif)

You can briefly see some gray text, which I believe is just the plain text of the latex input. It's then replaced by an SVG when it's ready.

It looks like there is a brief moment where the both the gray text and the svg is there. So I guess even with this change, it's possible that equations could still be doubled if the timer for pdf output is not long enough.

http://docs.mathjax.org/en/latest/options/extensions/fast-preview.html
