### PR TITLE
Disable Jekyll processing on GitHub Pages

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -84,6 +84,7 @@ ghp-import \
 
 # Deploy the webpage directory to gh-pages
 ghp-import \
+  --no-jekyll \
   --follow-links \
   --push \
   --branch=gh-pages \


### PR DESCRIPTION
Specify `--no-jekyll` to add a `.nojekyll` file to the `gh-pages` branch.

Manubot does not make use of Jekyll to do additional processing of webpage content hosted on GitHub Pages. Disable Jekyll to bypass an unnecessary CI job, which can slow down webpage deployment. https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/