### PR TITLE
fix link overflow

### DIFF
--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -102,6 +102,7 @@
     /* links */
     a {
         color: #2196f3;
+        word-break: break-word;
     }
 
     /* normal links (not empty, not button link, not syntax highlighting link) */
@@ -227,7 +228,6 @@
         border: solid 1px #bdbdbd;
         padding: 10px;
         /* squash table if too wide for page by forcing line breaks */
-        word-break: break-all;
         word-break: break-word;
     }
 

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -102,7 +102,7 @@
     /* links */
     a {
         color: #2196f3;
-        word-break: break-word;
+        overflow-wrap: break-word;
     }
 
     /* normal links (not empty, not button link, not syntax highlighting link) */
@@ -228,7 +228,7 @@
         border: solid 1px #bdbdbd;
         padding: 10px;
         /* squash table if too wide for page by forcing line breaks */
-        word-break: break-word;
+        overflow-wrap: break-word;
     }
 
     /* header row and even rows */
@@ -776,7 +776,7 @@
             border: solid 1px #bdbdbd;
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
             background: #ffffff;
-            word-break: break-word;
+            overflow-wrap: break-word;
         }
 
         /* tooltip copy of paragraphs and figures */

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -82,6 +82,8 @@ Horizontal rule:
 
 Bare URL link: <https://manubot.org>
 
+[Long link with lots of words and stuff and junk and bleep and blah and stuff and other stuff and more stuff yeah](https://manubot.org)
+
 [Link with text](https://manubot.org)
 
 [Link with hover text](https://manubot.org "Manubot Homepage")


### PR DESCRIPTION
This has been bugging me for a while:

![image](https://user-images.githubusercontent.com/8326331/64380255-9fbb3600-cffe-11e9-9218-4118a1228249.png)

Long links that can't break at a "natural" language point -- like links that have a lot of numbers I guess, it's dependent on the browser -- cause overflow to the right of the body/paper element.

I remember that I had previously had `word-break: break-all` for links, but that was causing them to break at unnatural points, like in between words, so we took it out, not remembering why it was there in the first place.

This PR adds it back in, but with `break-word`, which forces line breaks for long number links, but should also try to break them at natural points first.

___

Just to be sure, tested that it breaks at words:

![image](https://user-images.githubusercontent.com/8326331/64380722-94b4d580-cfff-11e9-96e3-91a130984182.png)

![image](https://user-images.githubusercontent.com/8326331/64380742-9f6f6a80-cfff-11e9-88ea-15c5f6b1b9e4.png)
