### PR TITLE
python webpage.py -> manubot webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bash build/build.sh
 # This is required to view local images in the HTML output.
 
 # Configure the webpage directory
-python build/webpage.py
+manubot webpage
 
 # You can now open the manuscript webpage/index.html in a web browser.
 # Alternatively, open a local webserver at http://localhost:8000/ with the
@@ -66,7 +66,7 @@ python -m http.server
 ```
 
 Sometimes it's helpful to monitor the content directory and automatically rebuild the manuscript when a change is detected.
-The following command, while running, will trigger both the `build.sh` and `webpage.py` scripts upon content changes:
+The following command, while running, will trigger both the `build.sh` script and `manubot webpage` command upon content changes:
 
 ```sh
 bash build/autobuild.sh

--- a/build/autobuild.sh
+++ b/build/autobuild.sh
@@ -5,5 +5,5 @@
 
 watchmedo shell-command \
   --wait \
-  --command='bash build/build.sh && python build/webpage.py' \
+  --command='bash build/build.sh && manubot webpage' \
   content

--- a/webpage/README.md
+++ b/webpage/README.md
@@ -19,7 +19,7 @@ In general, a version is identified by the commit hash of the source content tha
 
 The `*.ots` files in version directories are OpenTimestamps which can be used to verify manuscript existence at or before a given time.
 [OpenTimestamps](https://opentimestamps.org/) uses the Bitcoin blockchain to attest to file hash existence.
-The `deploy.sh` script run during continuous deployment creates the `.ots` files.
+The `deploy.sh` script run during continuous deployment creates the `.ots` files through its `manubot webpage` call.
 There is a delay before timestamps get confirmed by a Bitcoin block.
 Therefore, `.ots` files are initially incomplete and should be upgraded at a later time, so that they no longer rely on the availability of a calendar server to verify.
 `manubot webpage`, which is run during continuous deployment, identifies files matched by `webpage/v/**/*.ots` and attempts to upgrade them.

--- a/webpage/README.md
+++ b/webpage/README.md
@@ -22,7 +22,7 @@ The `*.ots` files in version directories are OpenTimestamps which can be used to
 The `deploy.sh` script run during continuous deployment creates the `.ots` files.
 There is a delay before timestamps get confirmed by a Bitcoin block.
 Therefore, `.ots` files are initially incomplete and should be upgraded at a later time, so that they no longer rely on the availability of a calendar server to verify.
-`webpage.py`, which is run during continuous deployment, identifies files matched by `webpage/v/**/*.ots` and attempts to upgrade them.
+`manubot webpage`, which is run during continuous deployment, identifies files matched by `webpage/v/**/*.ots` and attempts to upgrade them.
 You can also manually upgrade timestamps, by running the following in the `gh-pages` branch:
 
 ```sh

--- a/webpage/README.md
+++ b/webpage/README.md
@@ -22,7 +22,7 @@ The `*.ots` files in version directories are OpenTimestamps which can be used to
 The `deploy.sh` script run during continuous deployment creates the `.ots` files through its `manubot webpage` call.
 There is a delay before timestamps get confirmed by a Bitcoin block.
 Therefore, `.ots` files are initially incomplete and should be upgraded at a later time, so that they no longer rely on the availability of a calendar server to verify.
-`manubot webpage`, which is run during continuous deployment, identifies files matched by `webpage/v/**/*.ots` and attempts to upgrade them.
+The `manubot webpage` call during continuous deployment identifies files matched by `webpage/v/**/*.ots` and attempts to upgrade them.
 You can also manually upgrade timestamps, by running the following in the `gh-pages` branch:
 
 ```sh


### PR DESCRIPTION
Cleans up remaining mentions of `python build/webpage.py` to the new method `manubot webpage` -- continuing the transition from https://github.com/manubot/rootstock/pull/265