### PR TITLE
Explicitly specify PDF pagesize

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -103,6 +103,7 @@ if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
     arachnysdocker/athenapdf:2.16.0 \
     athenapdf \
     --delay=${MANUBOT_ATHENAPDF_DELAY:-1100} \
+    --pagesize=A4 \
     manuscript.html manuscript.pdf
   rm -rf output/images
 fi


### PR DESCRIPTION
Closes https://github.com/manubot/rootstock/issues/270

The existence of two common pagesizes for physical paper, A4 and Letter, creates user confusion. Sometimes users print a PDF with A4 dimensions onto Letter paper and do not use the "scale to fit" printer setting. This leads to truncated text at the bottom of the page. Ultimately, it is not a Manubot issue, but confuses Manubot users nonetheless.

When exporting the HTML to PDF Manubot uses an A4 pagesize, which while less common in the U.S. is an international standard. This commit explicitly specifies the default behavior, such that there is no functional change. However, by specifying the pagesize, its more clear to Manubot users where pagesize gets set. This will hopefully spare users extra debugging.

If manuscript viewers would like to export to a pagesize that is different from the one used by manuscript.pdf, the recommendation is for them to print the HTML page to PDF from their browser and specify the desired page size there. For this reason, our CSS style does not specify a default page size, but instead just a margin.

From [arachnys/athenapdf source](https://github.com/arachnys/athenapdf/blob/bf3d5d0070b079bc38f76f56aeb2ca09f3b3454c/cli/src/athenapdf.js#L39):

> athenapdf --pagesize <size>
> page size of the generated PDF (default: A4, values: A3|A4|A5|Legal|Letter|Tabloid)
