### PR TITLE
GH Actions: no setup deployment using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -42,14 +42,9 @@ jobs:
       - name: Deploy Manuscript
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         env:
-          MANUBOT_SSH_PRIVATE_KEY: ${{ secrets.MANUBOT_SSH_PRIVATE_KEY }}
+          SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_BUILD_WEB_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks
           CI_JOB_WEB_URL: https://github.com/${{ github.repository }}/runs/${{ github.run_id }}
-        shell: bash --login {0}        
+        shell: bash --login {0}
         run: |
-          if [ "$MANUBOT_SSH_PRIVATE_KEY" != "" ]; then
-            bash ci/deploy.sh
-          else
-            echo >&2 "Skipping deployment because the MANUBOT_SSH_PRIVATE_KEY secret is not set.
-            Instructions at https://github.com/manubot/rootstock/blob/master/SETUP.md#deploy-key"
-          fi
+          bash ci/deploy.sh

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -47,5 +47,4 @@ jobs:
           CI_BUILD_WEB_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks
           CI_JOB_WEB_URL: https://github.com/${{ github.repository }}/runs/${{ github.run_id }}
         shell: bash --login {0}
-        run: |
-          bash ci/deploy.sh
+        run: bash ci/deploy.sh

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -42,7 +42,8 @@ jobs:
       - name: Deploy Manuscript
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         env:
-          SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MANUBOT_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MANUBOT_SSH_PRIVATE_KEY: ${{ secrets.MANUBOT_SSH_PRIVATE_KEY }}
           CI_BUILD_WEB_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks
           CI_JOB_WEB_URL: https://github.com/${{ github.repository }}/runs/${{ github.run_id }}
         shell: bash --login {0}

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,7 +1,7 @@
 # Table of contents
 
 - [Table of contents](#table-of-contents)
-- [Cloning the manubot/rootstock repository to create a new manuscript](#cloning-the-manubot-rootstock-repository-to-create-a-new-manuscript)
+- [Creating a new manuscript](#creating-a-new-manuscript)
   * [Configuration](#configuration)
   * [Create repository](#create-repository)
   * [Continuous integration](#continuous-integration)
@@ -17,10 +17,12 @@
 
 _generated with [markdown-toc](https://ecotrust-canada.github.io/markdown-toc/)_
 
-# Cloning the manubot/rootstock repository to create a new manuscript
+# Creating a new manuscript
 
-The process to create a new Manubot manuscript is a bit challenging, because it requires a few steps that are difficult to automate.
+These instructions detail how to create a new manuscript based off of the [`manubot/rootstock`](https://github.com/manubot/rootstock/) repository.
+The process can be a bit challenging, because it requires a few steps that are difficult to automate.
 However, you will only have to perform these steps once for each manuscript.
+
 These steps should be performed in a command-line shell (terminal), starting in the directory where you want the manuscript folder be created.
 Setup is supported on Linux, macOS, and Windows.
 Windows setup requires [Git Bash](https://gitforwindows.org/) or [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq).

--- a/SETUP.md
+++ b/SETUP.md
@@ -83,6 +83,12 @@ Manubot integrates with cloud services to perform continuous integration (CI).
 For Manubot that means automatically building and deploying your manuscript.
 Manubot supports the following services:
 
+| Service | Default | Artifacts | Deployment | Config | Private Repos |
+|---------|---------|-----------|---------|--------|---------------|
+| [GitHub Actions](https://github.com/features/actions) | ✔️ | ✔️ | ✔️ | [`manubot.yaml`](.github/workflows/manubot.yaml) | 2,000 minutes per month |
+| [Travis CI](https://travis-ci.com) | ❌ | ❌ | ✔️ needs setup | [`.travis.yml`](.travis.yml) | 100 build trial |
+| [AppVeyor](https://www.appveyor.com/) | ❌ | ✔️ with PR comments | ❌ | [`.appveyor.yml`](.appveyor.yml) | 14 day trial |
+
 - [GitHub Actions](https://github.com/features/actions).
   Configured at [`.github/workflows/manubot.yaml`](.github/workflows/manubot.yaml)
 - [Travis CI](https://travis-ci.com).

--- a/SETUP.md
+++ b/SETUP.md
@@ -95,7 +95,7 @@ Manubot supports the following CI services:
 
 Notes on table fields:
 
-- **Default**: Whether the following SETUP instructions enable the service by default.
+- **Default**: Whether the following uncollapsed setup instructions enable the service by default.
 - **Artifacts**: Manuscript outputs that are saved alongside the CI build logs.
   Both GitHub Actions and AppVeyor upload the rendered manuscript as an artifact for pull request builds.
   However, only AppVeyor comments on pull requests with a download link to the artifacts ([example](https://github.com/manubot/rootstock/pull/262#issuecomment-519944731)).
@@ -241,23 +241,28 @@ AppVeyor only runs when it detects changes that are likely to affect the manuscr
 ## README updates
 
 The continuous integration configuration should now be complete.
-Now update `README.md` files to reference the new repository:
+Now update `README.md` files to reference your new repository:
 
-```sh
+```shell
 # Perform substitutions
 sed "s/manubot\/rootstock/$OWNER\/$REPO/g" README.md > tmp && mv -f tmp README.md
 sed "s/manubot\.github\.io\/rootstock/$OWNER\.github\.io\/$REPO/g" README.md > tmp && mv -f tmp README.md
-
-# Remove deletable content file
-git rm content/02.delete-me.md
 ```
 
 ## Finalize
 
+The `content/02.delete-me.md` file details the Markdown syntax and formatting options available with Manubot.
+Remove it to reduce the content to a blank manuscript:
+
+```shell
+# Remove deletable content file
+git rm content/02.delete-me.md
+```
+
 Run `git status` or `git diff --color-words` to double check the changes thus far.
 If the changes look okay, commit and push:
 
-```sh
+```shell
 git add --update
 git commit --message "Brand repo to $OWNER/$REPO"
 git push origin master

--- a/SETUP.md
+++ b/SETUP.md
@@ -114,7 +114,7 @@ git rm ci/install.sh
 ### Deploy key
 
 Deployment on Travis CI requires a SSH Deploy Key.
-Previousely, GitHub Actions also required an SSH Deploy Key, but now GitHub supports using `secrets.GITHUB_TOKEN`.
+Previously, GitHub Actions also required an SSH Deploy Key, but now GitHub supports using `secrets.GITHUB_TOKEN`.
 Therefore, users following the default configuration of deploying only via GitHub Actions can skip these steps.
 Otherwise, generate a deploy key so CI can write to the repository.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -95,9 +95,28 @@ We recommend using either GitHub Actions or Travis CI, but not both to avoid dep
 AppVeyor can be used in addition to GitHub Actions or Travis CI to comment on pull request with download links to rendered PDFs.
 GitHub Actions do upload rendered manuscripts as artifacts, but do not leave pull request comments.
 
+### GitHub Actions
+
+If you plan on only using GitHub actions, you can remove configuration files for other CI services:
+
+```shell
+# remove Travis CI config
+git rm .travis.yml
+# remove AppVeyor config
+git rm .appveyor.yml
+# remove ci/install.sh if not using neither Travis CI nor AppVeyor
+git rm ci/install.sh
+```
+
+<details>
+<summary>Expand for Deploy Key</summary>
+
 ### Deploy key
 
-Generate a deploy key so CI can write to the repository.
+Deployment on Travis CI requires a SSH Deploy Key.
+Previousely, GitHub Actions also required an SSH Deploy Key, but now GitHub supports using `secrets.GITHUB_TOKEN`.
+Therefore, users following the default configuration of deploying only via GitHub Actions can skip these steps.
+Otherwise, generate a deploy key so CI can write to the repository.
 
 ```sh
 # Generate deploy.key.pub (public) and deploy.key (private)
@@ -142,19 +161,7 @@ Click "Add a new secret".
 For "Name", enter `MANUBOT_SSH_PRIVATE_KEY`.
 Next, copy-paste the content of `ci/deploy.key.txt` into "Value"
 (printed above by `cat`, including any trailing `=` characters if present).
-
-### GitHub Actions
-
-If you plan on only using GitHub actions, you can remove configuration files for other CI services:
-
-```shell
-# remove Travis CI config
-git rm .travis.yml
-# remove AppVeyor config
-git rm .appveyor.yml
-# remove ci/install.sh if not using neither Travis CI nor AppVeyor
-git rm ci/install.sh
-```
+</details>
 
 <details>
 <summary>Expand for Travis CI setup</summary>

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,5 @@
 # Table of contents
 
-- [Table of contents](#table-of-contents)
 - [Creating a new manuscript](#creating-a-new-manuscript)
   * [Configuration](#configuration)
   * [Create repository](#create-repository)
@@ -97,6 +96,7 @@ Notes on table fields:
 
 - **Default**: Whether the following uncollapsed setup instructions enable the service by default.
 - **Artifacts**: Manuscript outputs that are saved alongside the CI build logs.
+  This is especially helpful for previewing changes that are under development in a pull request.
   Both GitHub Actions and AppVeyor upload the rendered manuscript as an artifact for pull request builds.
   However, only AppVeyor comments on pull requests with a download link to the artifacts ([example](https://github.com/manubot/rootstock/pull/262#issuecomment-519944731)).
 - **Deployment**: Whether the CI service can write outputs back to the GitHub repository (to the `output` and `gh-pages` branches).
@@ -105,6 +105,7 @@ Notes on table fields:
   Travis CI will only deploy if an SSH Private Key is provided.
   To avoid deploying a manuscript multiple times, disable GitHub Actions before providing an SSH Private Key to Travis.
 - **Config**: File configuring what operations CI will perform.
+  Removing this file is one method to disable the CI service.
 - **Private Repos**: Quota for private repos.
   Only GitHub Actions supports cost-free builds of private repositories beyond a trial period.
   All services are cost-free for public repos.
@@ -132,7 +133,7 @@ The following sections, collapsed by default, detail how to generate an SSH Depl
 
 ### SSH Deploy Key
 
-Deployment on Travis CI requires a SSH Deploy Key.
+Deployment on Travis CI requires an SSH Deploy Key.
 Previously, GitHub Actions also required an SSH Deploy Key, but now GitHub can deploy using the `GITHUB_TOKEN` secret.
 Therefore, users following the default configuration of deploying only via GitHub Actions can skip these steps.
 Otherwise, generate a deploy key so CI can write to the repository.

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## deploy.sh: run during a Travis CI build to deploy manuscript outputs to the output and gh-pages branches on GitHub.
+## deploy.sh: run during a CI build to deploy manuscript outputs to the output and gh-pages branches on GitHub.
 
 # Set options for extra caution & debugging
 set -o errexit \

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -28,9 +28,11 @@ git config --global user.name "$(git log --max-count=1 --format='%an')"
 git checkout "$BRANCH"
 
 if [ -v SECRET_GITHUB_TOKEN ] && [ "$SECRET_GITHUB_TOKEN" != "" ]; then
+  echo >&2 "[INFO] Detected SECRET_GITHUB_TOKEN. Will deploy via HTTPS."
   USE_GITHUB_TOKEN=true
   git remote set-url origin "https://$SECRET_GITHUB_TOKEN@github.com/$REPO_SLUG.git"
 else
+  echo >&2 "[INFO] Missing SECRET_GITHUB_TOKEN. Will deploy via SSH."
   USE_GITHUB_TOKEN=false
   git remote set-url origin "git@github.com:$REPO_SLUG.git"
 fi


### PR DESCRIPTION
Evaluates whether we can use `secrets.GITHUB_TOKEN` for deployment. Testing the PR in the repository https://github.com/dhimmel/rootstock-github-token.

Also noting https://github.com/dhimmel/rootstock-actions-deploy to test using [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages). However, I think that using our existing `deploy.sh` is less disruptive for now.