### PR TITLE
Do not deploy forked repositories

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   manubot:
     name: Manubot
-    if: '!github.repository.fork'
     runs-on: ubuntu-latest
     env:
       GITHUB_PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   manubot:
     name: Manubot
+    if: '!github.repository.fork'
     runs-on: ubuntu-latest
     env:
       GITHUB_PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
@@ -40,7 +41,7 @@ jobs:
           name: manuscript-${{ github.run_id }}-${{ env.TRIGGERING_SHA_7 }}
           path: output
       - name: Deploy Manuscript
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && !github.repository.fork
         env:
           MANUBOT_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MANUBOT_SSH_PRIVATE_KEY: ${{ secrets.MANUBOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
It looks like GitHub actions was also running on my fork. Now GitHub Actions deploys even without a manually set SSH Key. Therefore, it [tried to deploy on my fork](https://github.com/dhimmel/manubot-rootstock/commit/d14dd7dc8503fdae86c1a5f66777b62e11a0ebc6/checks?check_suite_id=465620679#step:7:17).