### PR TITLE
Simplify setup by creating branches later

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -46,14 +46,14 @@ REPO=rootstock
 **Execute the remaining commands verbatim.**
 They do not need to be edited (if the setup works as intended).
 
-Next you must clone `manubot/rootstock` and configure its branches and remotes:
+Next you must clone `manubot/rootstock` and reconfigure the remote repositories:
 
 ```sh
 # Clone manubot/rootstock
 git clone --single-branch https://github.com/manubot/rootstock.git $REPO
 cd $REPO
 
-# Configure remotes and branches
+# Configure remotes
 git remote add rootstock https://github.com/manubot/rootstock.git
 
 # Option A: Set origin URL using its web address
@@ -115,8 +115,8 @@ git rm .appveyor.yml
 git rm ci/install.sh
 ```
 
-GitHub Actions is able to deploy without any setup using the [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) for authentication.
-GitHub Pages deployment using `GITHUB_TOKEN` recently started working on GitHub without an official announcement.
+GitHub Actions is _usually_ able to deploy without any setup using the [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) for authentication.
+GitHub Pages deployment using `GITHUB_TOKEN` recently started _mostly_ working on GitHub without an official announcement.
 If it does not work for you, [let us know](https://github.com/manubot/rootstock/issues/new).
 One workaround is to use an SSH Deploy Key instead (see below).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -116,9 +116,11 @@ git rm ci/install.sh
 ```
 
 GitHub Actions is _usually_ able to deploy without any setup using the [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) for authentication.
-GitHub Pages deployment using `GITHUB_TOKEN` recently started _mostly_ working on GitHub without an official announcement.
-If it does not work for you, [let us know](https://github.com/manubot/rootstock/issues/new).
-One workaround is to use an SSH Deploy Key instead (see below).
+GitHub Pages deployment using `GITHUB_TOKEN` recently started working on GitHub without an official announcement.
+If it does not work for you after completing this setup, try reselecting "gh-pages branch" as the Source for GitHub Pages in the repository Settings.
+GitHub Pages should now trigger on the next commit.
+If not, [let us know](https://github.com/manubot/rootstock/issues/new).
+For more reliable deployment on GitHub, you can also use an SSH Deploy Key instead (see below).
 
 Deploying on Travis CI requires creating an SSH Deploy Key.
 The following sections, collapsed by default, detail how to generate an SSH Deploy Key.

--- a/SETUP.md
+++ b/SETUP.md
@@ -50,18 +50,11 @@ Next you must clone `manubot/rootstock` and configure its branches and remotes:
 
 ```sh
 # Clone manubot/rootstock
-git clone https://github.com/manubot/rootstock.git $REPO
+git clone --single-branch https://github.com/manubot/rootstock.git $REPO
 cd $REPO
 
 # Configure remotes and branches
 git remote add rootstock https://github.com/manubot/rootstock.git
-git checkout --orphan gh-pages
-git rm -r --force .
-git commit --allow-empty \
-  --message "Initialize empty branch" \
-  --message "[ci skip]"
-git checkout -b output
-git checkout master
 
 # Option A: Set origin URL using its web address
 git remote set-url origin https://github.com/$OWNER/$REPO.git
@@ -76,8 +69,6 @@ Next, push your cloned manuscript:
 
 ```sh
 git push --set-upstream origin master
-git push --set-upstream origin gh-pages
-git push --set-upstream origin output
 ```
 
 ## Continuous integration
@@ -125,6 +116,10 @@ git rm ci/install.sh
 ```
 
 GitHub Actions is able to deploy without any setup using the [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) for authentication.
+GitHub Pages deployment using `GITHUB_TOKEN` recently started working on GitHub without an official announcement.
+If it does not work for you, [let us know](https://github.com/manubot/rootstock/issues/new).
+One workaround is to use an SSH Deploy Key instead (see below).
+
 Deploying on Travis CI requires creating an SSH Deploy Key.
 The following sections, collapsed by default, detail how to generate an SSH Deploy Key.
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -64,7 +64,8 @@ fi
 # Fetch and create gh-pages and output branches
 # Travis does a shallow and single branch git clone
 git remote set-branches --add origin gh-pages output
-git fetch origin gh-pages:gh-pages output:output
+git fetch origin gh-pages:gh-pages output:output || \
+  echo >&2 "[INFO] could not fetch gh-pages or output from origin."
 
 # Configure versioned webpage and timestamp
 manubot webpage \


### PR DESCRIPTION
Prototyped in https://github.com/dhimmel/rootstock-branchless-setup

BTW I had some trouble initially having GITHUB_TOKEN deploy in https://github.com/dhimmel/rootstock-branchless-setup but I played around in settings and now it works I think. Must look into more