### PR TITLE
Export environment variables needed for gh-pages readme

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -17,7 +17,7 @@ BRANCH=${TRAVIS_BRANCH:-master}
 # Add commit hash to the README
 OWNER_NAME="$(dirname "$REPO_SLUG")"
 REPO_NAME="$(basename "$REPO_SLUG")"
-export OWNER_NAME REPO_NAME
+export REPO_SLUG COMMIT OWNER_NAME REPO_NAME
 envsubst < webpage/README.md > webpage/README-complete.md
 mv webpage/README-complete.md webpage/README.md
 


### PR DESCRIPTION
I noticed some of the automatically generated URLs are broken at https://github.com/manubot/rootstock/tree/gh-pages

My best guess is that these need to be exported before calling `envsubst`.  The exported variables are substituted correctly.