### PR TITLE
metadata: use list for author.funders

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -238,7 +238,8 @@ email: daniel.himmelstein@gmail.com  # suggested
 affiliations:  # as a list, strongly suggested
   - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
   - Department of Biological & Medical Informatics, University of California, San Francisco
-funders: GBMF4552  # optional
+funders:
+  - GBMF4552  # optional list of author's funding
 ```
 
 Note that `affiliations` should be a list to allow for multiple affiliations per author.

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -6,9 +6,9 @@ dependencies:
   - cairocffi=0.8.0
   - cffi=1.12.3
   - ghp-import=0.5.5
-  - jinja2=2.11.1
+  - jinja2=2.11.2
   - jsonschema=3.2.0
-  - pandas=1.0.1
+  - pandas=1.0.3
   - pandoc=2.9.2
   - pango=1.40.14
   - pip=20.0
@@ -17,10 +17,10 @@ dependencies:
   - pyyaml=5.3
   - requests=2.23.0
   - watchdog=0.10.2
-  - yamllint=1.20.0
+  - yamllint=1.21.0
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@a022e715f266c0f116a6b38f993bd696dc62094a
+    - git+https://github.com/manubot/manubot@9c33b7a53f60aa5aba42424b925af0c32ea561fb
     - jsonref==0.2
     - opentimestamps-client==0.7.0
     - opentimestamps==0.4.1

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -45,7 +45,7 @@ on {{manubot.date}}.
      {{author.affiliations | join('; ')}}
   {%- endif %}
   {%- if author.funders is defined and author.funders|length %}
-     · Funded by {{author.funders}}
+     · Funded by {{author.funders | join('; ')}}
   {%- endif %}
   </small>
 {% endfor %}

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -6,8 +6,7 @@ keywords:
   - manubot
 lang: en-US
 authors:
-  -
-    github: johndoe
+  - github: johndoe
     name: John Doe
     initials: JD
     orcid: XXXX-XXXX-XXXX-XXXX
@@ -15,9 +14,9 @@ authors:
     email: john.doe@something.com
     affiliations:
       - Department of Something, University of Whatever
-    funders: Grant XXXXXXXX
-  -
-    github: janeroe
+    funders:
+      - Grant XXXXXXXX
+  - github: janeroe
     name: Jane Roe
     initials: JR
     orcid: XXXX-XXXX-XXXX-XXXX


### PR DESCRIPTION
closes https://github.com/manubot/rootstock/issues/329

upgrade manubot with author.funders processing added in
https://github.com/manubot/manubot/commit/9c33b7a53f60aa5aba42424b925af0c32ea561fb