### PR TITLE
Enable pandoc spellcheck filter

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,11 +23,15 @@ image: ubuntu
 services:
   - docker
 
+# Set SPELLCHECK to true to enable Pandoc spellchecking
+environment:
+  SPELLCHECK: true
+
 install:
   # Create the message with the triggering commit before install so it is
   # available if the build fails
   - TRIGGERING_COMMIT=${APPVEYOR_PULL_REQUEST_HEAD_COMMIT:-APPVEYOR_REPO_COMMIT}
-  - appveyor AddMessage "commit $TRIGGERING_COMMIT"
+  - JOB_MESSAGE=" for commit $TRIGGERING_COMMIT "
   - source ci/install.sh
     
 test_script:
@@ -37,7 +41,13 @@ test_script:
   - cp output/manuscript.pdf $MANUSCRIPT_FILENAME.pdf
   - appveyor PushArtifact $MANUSCRIPT_FILENAME.html
   - appveyor PushArtifact $MANUSCRIPT_FILENAME.pdf
-
+  - |
+      if [ "${SPELLCHECK:-}" = "true" ]; then
+        SPELLING_ERRORS_FILENAME=spelling-errors-$APPVEYOR_BUILD_VERSION-${TRIGGERING_COMMIT:0:7}.txt
+        cp output/spelling-errors.txt $SPELLING_ERRORS_FILENAME;
+        appveyor PushArtifact $SPELLING_ERRORS_FILENAME
+      fi
+	
 build: off
 
 cache:
@@ -46,6 +56,16 @@ cache:
 on_success:
   - echo "Artifacts available from $APPVEYOR_URL/project/$APPVEYOR_ACCOUNT_NAME/$APPVEYOR_PROJECT_SLUG/builds/$APPVEYOR_BUILD_ID/artifacts"
   - echo "Updated PDF available from $APPVEYOR_URL/api/buildjobs/$APPVEYOR_JOB_ID/artifacts/$MANUSCRIPT_FILENAME.pdf"
+  - appveyor AddMessage "$JOB_MESSAGE is now complete."
+  - |
+      if [ "${SPELLCHECK:-}" = "true" ]; then
+        SPELLING_ERROR_COUNT=($(wc -l $SPELLING_ERRORS_FILENAME))
+        appveyor AddMessage " <details><summary>Found $SPELLING_ERROR_COUNT potential spelling error(s). Preview:</summary>$(cat $SPELLING_ERRORS_FILENAME)"
+        appveyor AddMessage "... </details>"
+      fi
+
+on_failure:
+  - appveyor AddMessage "$JOB_MESSAGE failed."
 
 # The following lines can be safely deleted, which will disable AppVeyorBot
 # notifications in GitHub pull requests
@@ -55,7 +75,6 @@ on_success:
 notifications:
   - provider: GitHubPullRequest
     template: "AppVeyor [build {{buildVersion}}]({{buildUrl}})
-      {{#jobs}}{{#messages}} for {{message}} by @{{&commitAuthorUsername}}{{/messages}}{{/jobs}}
-      {{#passed}} is now complete. The rendered manuscript from this build is temporarily available for download at:\n\n{{/passed}}
-      {{#failed}} failed.{{/failed}}
-      {{#jobs}}{{#artifacts}}- [`{{fileName}}`]({{permalink}})\n{{/artifacts}}{{/jobs}}"
+      {{#jobs}}{{#messages}}{{{message}}}{{/messages}}{{/jobs}}
+      {{#passed}}The rendered manuscript from this build is temporarily available for download at:\n\n
+      {{#jobs}}{{#artifacts}}- [`{{fileName}}`]({{permalink}})\n{{/artifacts}}{{/jobs}}{{/passed}}"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   - TRIGGERING_COMMIT=${APPVEYOR_PULL_REQUEST_HEAD_COMMIT:-APPVEYOR_REPO_COMMIT}
   - JOB_MESSAGE=" for commit $TRIGGERING_COMMIT "
   - source ci/install.sh
-    
+
 test_script:
   - bash build/build.sh
   - MANUSCRIPT_FILENAME=manuscript-$APPVEYOR_BUILD_VERSION-${TRIGGERING_COMMIT:0:7}
@@ -47,7 +47,7 @@ test_script:
         cp output/spelling-errors.txt $SPELLING_ERRORS_FILENAME;
         appveyor PushArtifact $SPELLING_ERRORS_FILENAME
       fi
-	
+
 build: off
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
 branches:
   only:
     - master
+env:
+  - SPELLCHECK=true
 install:
   - source ci/install.sh
 script:

--- a/USAGE.md
+++ b/USAGE.md
@@ -276,6 +276,13 @@ Changing the citation style or which interactive HTML plugins are loaded require
 The citation style is determined by the Citation Style Language file specified by `CSL_PATH`.
 It can be changed to use other existing styles as [described here](https://github.com/manubot/rootstock/issues/242#issuecomment-507688339).
 
+## Spellchecking
+
+When the `SPELLCHECK` environment variable is `true`, the pandoc [spellcheck filter](https://github.com/pandoc/lua-filters/tree/master/spellcheck) is run.
+Potential spelling errors will be printed in the continuous integration log along with the files and line numbers in which they appeared.
+Words in `build/assets/custom-dictionary.txt` are ignored during spellchecking.
+Spellchecking is currently only supported for English language manuscripts and with Travis CI and AppVeyor continuous integration services.
+
 ## Manubot feedback
 
 If you experience any issues with the Manubot or would like to contribute to its source code, please visit [`manubot/manubot`](https://github.com/manubot/manubot) or [`manubot/rootstock`](https://github.com/manubot/rootstock).

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -1,3 +1,21 @@
-personal_ws-1.1 en 2
+personal_ws-1.1 en 20
+al
+DOI
+et
+isbn
+LaTeX
+manubot
 Manubot
+ORCID
+permalink
+PMC
+pmcid
+pmid
+PubMed
+rootstock
 Rootstock
+s
+Strikethrough
+SVGs
+unicode
+Wikidata

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -1,0 +1,3 @@
+personal_ws-1.1 en 2
+Manubot
+Rootstock

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -1,19 +1,22 @@
-personal_ws-1.1 en 18
+personal_ws-1.1 en 21
 al
-DOI
+doi
+eq
 et
 isbn
-LaTeX
+latex
 manubot
-ORCID
+orcid
 permalink
-PMC
+pmc
 pmcid
 pmid
-PubMed
+pubmed
 rootstock
 s
-Strikethrough
-SVGs
+strikethrough
+svg
+svgs
+tbl
 unicode
-Wikidata
+wikidata

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -1,11 +1,10 @@
-personal_ws-1.1 en 20
+personal_ws-1.1 en 18
 al
 DOI
 et
 isbn
 LaTeX
 manubot
-Manubot
 ORCID
 permalink
 PMC
@@ -13,7 +12,6 @@ pmcid
 pmid
 PubMed
 rootstock
-Rootstock
 s
 Strikethrough
 SVGs

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -1,8 +1,9 @@
-personal_ws-1.1 en 21
+personal_ws-1.1 en 22
 al
 doi
 eq
 et
+github
 isbn
 latex
 manubot

--- a/build/build.sh
+++ b/build/build.sh
@@ -85,7 +85,10 @@ fi
 # Spellcheck
 if [ "${SPELLCHECK:-}" = "true" ]; then
   export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt; ignore-case true"
-  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -on "\<$word\>" content/*md; done | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-errors.txt
+  # Use "|| true" after grep because otherwise this step of the pipeline will
+  # return exit code 1 if any of the markdown files do not contain a
+  # misspelled word
+  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -ion "\<$word\>" content/*.md; done || true | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-errors.txt
   cat output/spelling-errors.txt
 fi
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -84,7 +84,7 @@ fi
 
 # Spellcheck
 if [ "${SPELLCHECK:-}" = "true" ]; then
-  export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt"
+  export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt; ignore-case true"
   pandoc --lua-filter spellcheck.lua output/manuscript.md | sort | uniq > output/spelling-errors.txt
   cat output/spelling-errors.txt
 fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -85,7 +85,7 @@ fi
 # Spellcheck
 if [ "${SPELLCHECK:-}" = "true" ]; then
   export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt; ignore-case true"
-  pandoc --lua-filter spellcheck.lua output/manuscript.md | sort | uniq > output/spelling-errors.txt
+  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -on "\<$word\>" output/manuscript.md; done | sort -h > output/spelling-errors.txt
   cat output/spelling-errors.txt
 fi
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -85,7 +85,7 @@ fi
 # Spellcheck
 if [ "${SPELLCHECK:-}" = "true" ]; then
   export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt; ignore-case true"
-  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -on "\<$word\>" output/manuscript.md; done | sort -h > output/spelling-errors.txt
+  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -on "\<$word\>" content/*md; done | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-errors.txt
   cat output/spelling-errors.txt
 fi
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -82,4 +82,10 @@ if [ "${BUILD_DOCX:-}" = "true" ]; then
     --defaults="$PANDOC_DEFAULTS_DIR/docx.yaml"
 fi
 
+# Spellcheck
+if [ "${SPELLCHECK:-}" = "true" ]; then
+  export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt"
+  pandoc --lua-filter spellcheck.lua output/manuscript.md | sort | uniq > output/spelling-errors.txt
+fi
+
 echo >&2 "Build complete"

--- a/build/build.sh
+++ b/build/build.sh
@@ -88,7 +88,8 @@ if [ "${SPELLCHECK:-}" = "true" ]; then
   # Use "|| true" after grep because otherwise this step of the pipeline will
   # return exit code 1 if any of the markdown files do not contain a
   # misspelled word
-  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -ion "\<$word\>" content/*.md; done || true | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-errors.txt
+  pandoc --lua-filter spellcheck.lua output/manuscript.md | uniq | while read word; do grep -ion "\<$word\>" content/*.md; done | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-errors.txt || true
+  echo >&2 "Filenames and line numbers with potential spelling errors:"
   cat output/spelling-errors.txt
 fi
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -86,6 +86,7 @@ fi
 if [ "${SPELLCHECK:-}" = "true" ]; then
   export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt"
   pandoc --lua-filter spellcheck.lua output/manuscript.md | sort | uniq > output/spelling-errors.txt
+  cat output/spelling-errors.txt
 fi
 
 echo >&2 "Build complete"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -19,7 +19,6 @@ conda list --name manubot
 conda activate manubot
 
 # Install Spellcheck filter for Pandoc
-# Only tested in AppVeyor
 if [ "${SPELLCHECK:-}" = "true" ]; then
   sudo apt-get update -y
   sudo apt-get install -y aspell aspell-en

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,3 +17,11 @@ conda config \
 conda env create --quiet --file build/environment.yml
 conda list --name manubot
 conda activate manubot
+
+# Install Spellcheck filter for Pandoc
+# Only tested in AppVeyor
+if [ "${SPELLCHECK:-}" = "true" ]; then
+  sudo apt-get update -y
+  sudo apt-get install -y aspell aspell-en
+  wget https://raw.githubusercontent.com/pandoc/lua-filters/1c553017ecc58914c22bf2372902dca4a456929b/spellcheck/spellcheck.lua
+fi


### PR DESCRIPTION
References https://github.com/manubot/manubot/issues/31
Initial implementation from https://github.com/agitter/my-manuscript/pull/15

There are a few open questions to discuss:
- [x] Where should this be documented (`SETUP.md`?)
- [x] Should it be enabled in AppVeyor builds by default (I vote yes)
- [x] Should it be enabled in Travis CI builds by default?
- [x] What should be in the initial custom dictionary?

I've noticed that many spelling errors come from `00.front-matter.md`.  We could automatically add all of the manuscript metadata to the custom dictionary, but then we would ignore typos in affiliations or titles.  I would prefer to save that for a separate pull request even if we do want it.