### PR TITLE
fix some hypothesis issues

### DIFF
--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -42,9 +42,7 @@
         // create button
         const button = document.createElement('button');
         button.id = 'hypothesis_button';
-        button.innerHTML = document.querySelector(
-            '.icon_hypothesis'
-        ).innerHTML;
+        button.innerHTML = document.querySelector('.icon_hypothesis').innerHTML;
         button.title = 'Hypothesis annotations';
         button.classList.add('icon_button');
 

--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -63,7 +63,8 @@
         try {
             const canonical = document.querySelector('link[rel="canonical"]');
             const location = window.location;
-            const response = await fetch(query + (canonical || location).href);
+            const url = encodeURIComponent((canonical || location).href);
+            const response = await fetch(query + url);
             const json = await response.json();
             count = json.total || '-';
         } catch(error) {
@@ -93,10 +94,10 @@
 
 <template class="icon_hypothesis">
     <!-- modified from: https://fontawesome.com/icons/quote-right -->
-    <svg width="16" height="16" viewBox="0 0 512 512" tabindex="-1">
+    <svg width="16" height="16" viewBox="0 0 24 24" tabindex="-1">
         <path
             fill="currentColor"
-            d="M464 32H336c-26.5 0-48 21.5-48 48v128c0 26.5 21.5 48 48 48h80v64c0 35.3-28.7 64-64 64h-8c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24h8c88.4 0 160-71.6 160-160V80c0-26.5-21.5-48-48-48zm-288 0H48C21.5 32 0 53.5 0 80v128c0 26.5 21.5 48 48 48h80v64c0 35.3-28.7 64-64 64h-8c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24h8c88.4 0 160-71.6 160-160V80c0-26.5-21.5-48-48-48z"
+            d="M3.43 0C2.5 0 1.72 .768 1.72 1.72V18.86C1.72 19.8 2.5 20.57 3.43 20.57H9.38L12 24L14.62 20.57H20.57C21.5 20.57 22.29 19.8 22.29 18.86V1.72C22.29 .77 21.5 0 20.57 0H3.43M5.14 3.43H7.72V9.43S8.58 7.72 10.28 7.72C12 7.72 13.74 8.57 13.74 11.24V17.14H11.16V12C11.16 10.61 10.28 10.07 9.43 10.29C8.57 10.5 7.72 11.41 7.72 13.29V17.14H5.14V3.43M18 13.72C18.95 13.72 19.72 14.5 19.72 15.42A1.71 1.71 0 0 1 18 17.13A1.71 1.71 0 0 1 16.29 15.42C16.29 14.5 17.05 13.71 18 13.71Z"
             tabindex="-1"
         ></path>
     </svg>

--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -63,7 +63,10 @@
         // get annotation count from Hypothesis based on url
         let count = '-';
         try {
-            const response = await fetch(query + window.location.href);
+            const canonical = 
+                (document.querySelector('link[rel="canonical"]') || {}).href;
+            const url = window.location.href;
+            const response = await fetch(query + (canonical || url));
             const json = await response.json();
             count = json.total || '-';
         } catch(error) {

--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -1,6 +1,16 @@
-<!-- annotations plugin configuration -->
+<!-- annotations plugin -->
 
 <script>
+    // /////////////////////////
+    // DESCRIPTION
+    // /////////////////////////
+
+    // This third-party plugin 'Hypothesis' allows public annotation of the
+    // manuscript.
+
+    // https://web.hypothes.is/
+
+    // plugin configuration
     window.hypothesisConfig = function() {
         return {
             branding: {
@@ -13,17 +23,81 @@
             }
         };
     };
+
+    // hypothesis client script
+    const embed = 'https://hypothes.is/embed.js';
+    // hypothesis annotation count query url
+    const query = 'https://api.hypothes.is/api/search?limit=0&url='
+
+    
+    // start script
+    function start() {
+        const button = makeButton();
+        document.body.insertBefore(button, document.body.firstChild);
+        insertCount(button);
+    }
+
+    // make button
+    function makeButton() {
+        // create button
+        const button = document.createElement('button');
+        button.id = 'hypothesis_button';
+        button.innerHTML = document.querySelector(
+            '.icon_hypothesis'
+        ).innerHTML;
+        button.title = 'Hypothesis annotations';
+        button.classList.add('icon_button');
+
+        function onClick(event) {
+            onButtonClick(event, button);
+        }
+
+        // attach click listeners
+        button.addEventListener('click', onClick);
+
+        return button;
+    }
+
+    // insert annotations count
+    async function insertCount(button) {
+        // get annotation count from Hypothesis based on url
+        let count = '-';
+        try {
+            const response = await fetch(query + window.location.href);
+            const json = await response.json();
+            count = json.total || '-';
+        } catch(error) {
+            console.log(error);
+        }
+        
+        // put count into button
+        const counter = document.createElement('span');
+        counter.id = 'hypothesis_count';
+        counter.innerHTML = count;
+        button.title = 'View ' + count + ' Hypothesis annotations';
+        button.append(counter);
+    }
+
+    // when button is clicked
+    function onButtonClick(event, button) {
+        const script = document.createElement('script');
+        script.src = embed;
+        document.body.append(script);
+        button.remove();
+    }
+
+    window.addEventListener('load', start);
 </script>
 
-<!-- annotations plugin -->
+<!-- hypothesis icon -->
 
-<script src='https://hypothes.is/embed.js'>
-    // /////////////////////////
-    // DESCRIPTION
-    // /////////////////////////
-
-    // This third-party plugin 'Hypothesis' allows public annotation of the
-    // manuscript.
-
-    // https://web.hypothes.is/
-</script>
+<template class="icon_hypothesis">
+    <!-- modified from: https://fontawesome.com/icons/quote-right -->
+    <svg width="16" height="16" viewBox="0 0 512 512" tabindex="-1">
+        <path
+            fill="currentColor"
+            d="M464 32H336c-26.5 0-48 21.5-48 48v128c0 26.5 21.5 48 48 48h80v64c0 35.3-28.7 64-64 64h-8c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24h8c88.4 0 160-71.6 160-160V80c0-26.5-21.5-48-48-48zm-288 0H48C21.5 32 0 53.5 0 80v128c0 26.5 21.5 48 48 48h80v64c0 35.3-28.7 64-64 64h-8c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24h8c88.4 0 160-71.6 160-160V80c0-26.5-21.5-48-48-48z"
+            tabindex="-1"
+        ></path>
+    </svg>
+</template>

--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -93,7 +93,7 @@
 <!-- hypothesis icon -->
 
 <template class="icon_hypothesis">
-    <!-- modified from: https://fontawesome.com/icons/quote-right -->
+    <!-- modified from: https://simpleicons.org/icons/hypothesis.svg / https://git.io/Jf1VB -->
     <svg width="16" height="16" viewBox="0 0 24 24" tabindex="-1">
         <path
             fill="currentColor"

--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -63,10 +63,9 @@
         // get annotation count from Hypothesis based on url
         let count = '-';
         try {
-            const canonical = 
-                (document.querySelector('link[rel="canonical"]') || {}).href;
-            const url = window.location.href;
-            const response = await fetch(query + (canonical || url));
+            const canonical = document.querySelector('link[rel="canonical"]');
+            const location = window.location;
+            const response = await fetch(query + (canonical || location).href);
             const json = await response.json();
             count = json.total || '-';
         } catch(error) {

--- a/build/plugins/table-of-contents.html
+++ b/build/plugins/table-of-contents.html
@@ -169,9 +169,7 @@
             // create toc button
             const button = document.createElement('button');
             button.id = 'toc_button';
-            button.innerHTML = document.querySelector(
-                '.icon_th_list'
-            ).innerHTML;
+            button.innerHTML = document.querySelector('.icon_th_list').innerHTML;
             button.title = 'Table of Contents';
             button.classList.add('icon_button');
 

--- a/build/plugins/table-of-contents.html
+++ b/build/plugins/table-of-contents.html
@@ -172,11 +172,12 @@
             button.innerHTML = document.querySelector(
                 '.icon_th_list'
             ).innerHTML;
+            button.title = 'Table of Contents';
             button.classList.add('icon_button');
 
             // create header text
             const text = document.createElement('h3');
-            text.innerHTML = 'Table of Contents';
+            text.innerHTML = 'View Table of Contents';
 
             // create container for toc list
             const list = document.createElement('div');

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -80,6 +80,26 @@
         border-bottom: solid 1px #bdbdbd;
     }
 
+    /* heading font sizes */
+    h1 {
+        font-size: 2em;
+    }
+    h2 {
+        font-size: 1.5em;
+    }
+    h3{
+        font-size: 1.35em;
+    }
+    h4 {
+        font-size: 1.25em;
+    }
+    h5 {
+        font-size: 1.15em;
+    }
+    h6 {
+        font-size: 1em;
+    }
+
     /* -------------------------------------------------- */
     /* manuscript header */
     /* -------------------------------------------------- */
@@ -1182,10 +1202,39 @@
     /* hypothesis (annotations) plugin */
     /* -------------------------------------------------- */
 
+    /* hypothesis activation button */
+    #hypothesis_button {
+        box-sizing: border-box;
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 60px;
+        height: 60px;
+        background: #ffffff;
+        border-radius: 0;
+        border-left: solid 1px #bdbdbd;
+        border-bottom: solid 1px #bdbdbd;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
+        z-index: 2;
+    }
+
+    /* hypothesis button svg */
+    #hypothesis_button > svg {
+        position: relative;
+        top: -4px;
+    }
+
+    /* hypothesis annotation count */
+    #hypothesis_count {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 5px;
+    }
+
     /* side panel */
     .annotator-frame {
         width: 280px !important;
-        z-index: 0 !important;
     }
 
     /* match highlight color to rest of theme */

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -533,22 +533,6 @@
             margin: 15px 0;
         }
 
-        /* heading 1 */
-        h1 {
-            font-size: 1.75em;
-        }
-
-        /* heading 2 */
-        h2 {
-            font-size: 1.25em;
-            margin-top: 0;
-        }
-
-        /* heading 3 */
-        h3 {
-            font-size: 1.10em;
-        }
-
         /* figures and tables */
         figure, table {
             font-size: 0.85em;

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -1252,8 +1252,12 @@
         background: #f5f5f5 !important;
     }
 
-    /* always hide toolbar and tooltip on print */
+    /* always hide button, toolbar, and tooltip on print */
     @media only print {
+        #hypothesis_button {
+            display: none;
+        }
+
         .annotator-frame {
             display: none !important;
         }

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -63,6 +63,10 @@ Document section headings:
 
 #### Heading 4
 
+##### Heading 5
+
+###### Heading 6
+
 ### A heading centered on its own printed page{.center .page_center}
 
 <!-- an arbitrary comment. visible in input, but not visible in output. -->


### PR DESCRIPTION
closes https://github.com/manubot/rootstock/issues/306
closes https://github.com/manubot/rootstock/issues/293
closes https://github.com/manubot/rootstock/issues/280
closes https://github.com/manubot/rootstock/issues/281 

- changes default font sizes of h1 through h6 to be larger than base text size, breaking with browser precedent
- fixes overlap of hypothesis sidebar and table of contents plugin on small screens
- adds button to load hypothesis plugin, rather than automatically loading it

![image](https://user-images.githubusercontent.com/8326331/83823987-470aed80-a6a3-11ea-9816-b3caab325b11.png)
