### PR TITLE
Update Pandoc to 2.10

### DIFF
--- a/build/environment.yml
+++ b/build/environment.yml
@@ -8,18 +8,18 @@ dependencies:
   - ghp-import=0.5.5
   - jinja2=2.11.2
   - jsonschema=3.2.0
-  - pandoc=2.9.2
+  - pandoc=2.10
   - pango=1.40.14
-  - pip=20.0
+  - pip=20.1
   - psutil=5.7.0
-  - python=3.7.6
+  - python=3.7
   - pyyaml=5.3
-  - requests=2.23.0
-  - watchdog=0.10.2
-  - yamllint=1.21.0
+  - requests=2.24
+  - watchdog=0.10.3
+  - yamllint=1.23.0
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@31968197d1ccd96a46bf092cdba4b575764bb954
+    - git+https://github.com/manubot/manubot@a57ccf0be6972329ff3010eaaa0c5df7ccebb2d5
     - opentimestamps-client==0.7.0
     - opentimestamps==0.4.1
     - pandoc-eqnos==2.1.1

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -22,10 +22,10 @@ dependencies:
     - git+https://github.com/manubot/manubot@a57ccf0be6972329ff3010eaaa0c5df7ccebb2d5
     - opentimestamps-client==0.7.0
     - opentimestamps==0.4.1
-    - pandoc-eqnos==2.1.1
-    - pandoc-fignos==2.2.0
-    - pandoc-tablenos==2.1.1
-    - pandoc-xnos==2.2.0
+    - pandoc-eqnos==2.2.0
+    - pandoc-fignos==2.3.0
+    - pandoc-tablenos==2.2.0
+    - pandoc-xnos==2.4.1
     - pybase62==0.4.3
     - pysha3==1.0.2
     - python-bitcoinlib==0.10.2

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - ghp-import=0.5.5
   - jinja2=2.11.2
   - jsonschema=3.2.0
-  - pandoc=2.10
+  - pandoc=2.10.1
   - pango=1.40.14
   - pip=20.1
   - psutil=5.7.0


### PR DESCRIPTION
Update other dependencies that aren't held back due to weasyprint/
ciaro to latest on 2020-07-02

https://github.com/jgm/pandoc/releases/tag/2.10