### PR TITLE
Add a plugin for d3 loading

### DIFF
--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -1,5 +1,6 @@
 # Pandoc --defaults for HTML output.
 # Load on top of common defaults.
+# By default, the d3js pluging is disabled.
 to: html5
 output-file: output/manuscript.html
 include-after-body:
@@ -15,6 +16,7 @@ include-after-body:
 - build/plugins/math.html
 - build/plugins/hypothesis.html
 - build/plugins/analytics.html
+#- build/plugins/d3.html
 variables:
   math: ''
 html-math-method:

--- a/build/plugins/d3.html
+++ b/build/plugins/d3.html
@@ -1,11 +1,43 @@
 <!-- d3 plugin -->
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js" integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw==" crossorigin="anonymous">
+<script>
+    var d3ScriptTag = document.createElement('script');
+    d3ScriptTag.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js");
+    d3ScriptTag.setAttribute("integrity", "sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw==");
+    d3ScriptTag.setAttribute("crossorigin", "anonymous");
+    document.head.appendChild(d3ScriptTag);
+
+    // https://stackoverflow.com/questions/35783441/include-svg-files-with-html-and-still-be-able-to-apply-styles-to-them
+    replaceElementWithInline = (e) =>
+        fetch(e.getAttribute(e.nodeName === "OBJECT" ? "data" : "src"))
+            .then(response => response.text())
+            .then(text => { e.outerHTML = text; return Promise.resolve(); });
+
+    d3ScriptTag.onload = function() {
+        var exchanges = [];
+        d3.selectAll("figure>img")
+            .filter((d, i, n) => n[i].src.endsWith(".svg"))
+            .each((d, i, n) => exchanges.push(replaceElementWithInline(n[i])));
+        Promise.all(exchanges).then(e => {
+            document.dispatchEvent(new Event("D3Loaded"));
+        });
+    }
     // /////////////////////////
     // DESCRIPTION
     // /////////////////////////
 
     // This third-party plugin 'd3' allows embedded scripts to utilize the d3
     // platform inline in manubot documents.
+    //
+    // It does this by first loading in and replacing figure <img> tags that
+    // include SVG files with the content of those files, then firing the D3Loaded event
+    // at the document level.
+    //
+    // To take advantage of this, you can use inline <script> components that listen
+    // for the document's D3Loaded event, like so:
+    //
+    // document.addEventListener("D3Loaded", function(event) {
+    //    ... do your stuff here ...
+    // });
 
 </script>

--- a/build/plugins/d3.html
+++ b/build/plugins/d3.html
@@ -1,0 +1,11 @@
+<!-- d3 plugin -->
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js" integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw==" crossorigin="anonymous">
+    // /////////////////////////
+    // DESCRIPTION
+    // /////////////////////////
+
+    // This third-party plugin 'd3' allows embedded scripts to utilize the d3
+    // platform inline in manubot documents.
+
+</script>


### PR DESCRIPTION
This adds a plugin to use d3 in the document HTML.

At present, it's disabled by default, as it does two things -- it both converts figures containing SVGs into inline SVGs rather than IMG tags, and it loads d3 from a CDN.

As discussed in the documentation, it sets up a D3Loaded event that it fires once all SVG-containing figures have been inlined.

I don't know if this is worth an example, or if it even fits with the idea of Manubot.  I went this route as it seemed to be the easiest way to preserve the output from PDF and other conversions for SVG figures while still allowing some in-line interaction.
