### PR TITLE
GitHub Actions: use Environment Files not set-env

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -17,8 +17,7 @@ jobs:
       - name: Set Environment Variables
         run: |
           TRIGGERING_SHA=${GITHUB_PULL_REQUEST_SHA:-$GITHUB_SHA}
-          TRIGGERING_SHA_7=${TRIGGERING_SHA::7}
-          echo "::set-env name=TRIGGERING_SHA_7::$TRIGGERING_SHA_7"
+          echo "TRIGGERING_SHA_7=${TRIGGERING_SHA::7}" >> $GITHUB_ENV
           echo "TRIGGERING_SHA: $TRIGGERING_SHA"
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
From https://github.com/manubot/rootstock/runs/1212860980#step:2:10:

> Warning: The `set-env` command is deprecated and will be disabled soon.
> Please upgrade to using Environment Files.
> For more information see:
> https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable