### PR TITLE
Add "inline svg" and "d3" plugins

### DIFF
--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -2,8 +2,11 @@
 # Load on top of common defaults.
 to: html5
 output-file: output/manuscript.html
+include-in-header:
+# - build/plugins/d3.html
 include-after-body:
 - build/themes/default.html
+# - build/plugins/inline-svg.html
 - build/plugins/anchors.html
 - build/plugins/accordion.html
 - build/plugins/tooltips.html
@@ -11,8 +14,6 @@ include-after-body:
 - build/plugins/link-highlight.html
 - build/plugins/table-of-contents.html
 - build/plugins/lightbox.html
-# - build/plugins/inline-svg.html
-# - build/plugins/d3.html
 - build/plugins/attributes.html
 - build/plugins/math.html
 - build/plugins/hypothesis.html

--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -2,7 +2,7 @@
 # Load on top of common defaults.
 to: html5
 output-file: output/manuscript.html
-include-in-header:
+include-before-body:
 # - build/plugins/d3.html
 include-after-body:
 - build/themes/default.html

--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -11,6 +11,8 @@ include-after-body:
 - build/plugins/link-highlight.html
 - build/plugins/table-of-contents.html
 - build/plugins/lightbox.html
+# - build/plugins/inline-svg.html
+# - build/plugins/d3.html
 - build/plugins/attributes.html
 - build/plugins/math.html
 - build/plugins/hypothesis.html

--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -2,7 +2,7 @@
 # Load on top of common defaults.
 to: html5
 output-file: output/manuscript.html
-include-before-body:
+# include-before-body:
 # - build/plugins/d3.html
 include-after-body:
 - build/themes/default.html

--- a/build/plugins/d3.html
+++ b/build/plugins/d3.html
@@ -1,0 +1,16 @@
+<!-- d3 plugin -->
+
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"
+  integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw=="
+  crossorigin="anonymous"
+>
+  // /////////////////////////
+  // DESCRIPTION
+  // /////////////////////////
+
+  // This third-party plugin 'D3' allows you to create complex, dynamic,
+  // interactive, data-driven visualizations in SVG.
+
+  // https://d3js.org/
+</script>

--- a/build/plugins/d3.html
+++ b/build/plugins/d3.html
@@ -1,16 +1,16 @@
 <!-- d3 plugin -->
 
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"
-  integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw=="
-  crossorigin="anonymous"
+    src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"
+    integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw=="
+    crossorigin="anonymous"
 >
-  // /////////////////////////
-  // DESCRIPTION
-  // /////////////////////////
+    // /////////////////////////
+    // DESCRIPTION
+    // /////////////////////////
 
-  // This third-party plugin 'D3' allows you to create complex, dynamic,
-  // interactive, data-driven visualizations in SVG.
+    // This third-party plugin 'D3' allows you to create complex, dynamic,
+    // interactive, data-driven visualizations in SVG.
 
-  // https://d3js.org/
+    // https://d3js.org/
 </script>

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -7,13 +7,13 @@
       // /////////////////////////
 
       // This Manubot plugin fetches the text source code of SVGs in <img> tags,
-      // and inserts it into the document in place. This provides many
+      // and inserts it into the document in-place. This provides many
       // advantages, such as being able to style SVGs globally from the CSS
       // themes, and being able to make SVGs interactive with JavaScript and D3.
-      // If you have a script that expects SVGs to be inlined, wait for a
+      // If you have a script that expects SVGs to be inlined, wait for an
       // "SVGLoaded" event before running it.
 
-      // Note: This requires the page to be served from a server to work.
+      // Note: This requires the page to be served from a server to work
       // See: https://stackoverflow.com/a/11063963/2180570
       // Tip: Use the manubot commands to open the page in a local webserver
       // See: https://github.com/manubot/rootstock#local-execution
@@ -38,7 +38,7 @@
           try {
               // fetch svg source code
               const response = await fetch(img.src);
-              if (!response.ok) throw new Error('Couldn\'t get SVG source')
+              if (!response.ok) throw new Error('Couldn\'t get SVG source');
               const source = await response.text();
               if (!source.trim()) throw new Error('No SVG source');
               // parse specifically as svg, create new (hidden) dom node

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -28,7 +28,7 @@
       }
 
       // takes an svg <img> tag, fetches its source code, and replaces it 
-      async function inlineSvg(img) {
+      async function inlineSvg(svg) {
         const text = await (await fetch(svg.src)).text();
         svg.outerHTML = text;
       }

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -27,12 +27,25 @@
           document.dispatchEvent(new Event('D3Loaded'));
       }
 
-      // takes an svg <img> tag, fetches its source code, and replaces it 
-      async function inlineSvg(svg) {
+      // take an svg <img> tag, fetch its source code, and replace it 
+      async function inlineSvg(img) {
           try {
-              const text = await (await fetch(svg.src)).text();
-              svg.outerHTML = text;
-          } catch(error) {
+              // fetch svg source code
+              const response = await fetch(img.src);
+              if (!response.ok) throw new Error('No SVG source')
+              const source = await response.text();
+              if (!source.trim()) throw new Error('No SVG source');
+              // parse specifically as svg, create new (hidden) dom node
+              const svg = new DOMParser()
+                  .parseFromString(source, 'image/svg+xml')
+                  .querySelector('svg');
+              if (!svg) throw new Error('Couldn\'t parse SVG');
+              // transfer original img attributes into new svg
+              for (const { name, value } of img.attributes)
+                  svg.setAttribute(name, value);
+              // replace original image with new svg
+              img.outerHTML = svg.outerHTML;
+          } catch (error) {
               console.log(error);
           }
       }

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -10,6 +10,8 @@
       // and inserts it into the document in place. This provides many
       // advantages, such as being able to style SVGs globally from the CSS
       // themes, and being able to make SVGs interactive with JavaScript and D3.
+      // If you have a script that expects SVGs to be inlined, wait for a
+      // "SVGLoaded" event before running it.
 
       // Note: This requires the page to be served from a server to work.
       // See: https://stackoverflow.com/a/11063963/2180570
@@ -28,8 +30,7 @@
           await Promise.all(inlineSvgs);
 
           // dispatch "inline finished" event
-          // user d3 scripts should wait to hear this event before running
-          document.dispatchEvent(new Event('D3Loaded'));
+          document.dispatchEvent(new Event('SVGLoaded'));
       }
 
       // take an svg <img> tag, fetch its source code, and replace it 

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -29,9 +29,12 @@
 
       // takes an svg <img> tag, fetches its source code, and replaces it 
       async function inlineSvg(svg) {
-        const text = await (await fetch(svg.src)).text();
-        if (text)
-            svg.outerHTML = text;
+          try {
+              svg.outerHTML =
+                  await (await fetch(svg.src)).text() || svg.outerHTML;
+          } catch(error) {
+              console.log(error);
+          }
       }
 
       // start script when document is finished loading

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -30,8 +30,8 @@
       // takes an svg <img> tag, fetches its source code, and replaces it 
       async function inlineSvg(svg) {
           try {
-              svg.outerHTML =
-                  await (await fetch(svg.src)).text() || svg.outerHTML;
+              const text = await (await fetch(svg.src)).text();
+              svg.outerHTML = text;
           } catch(error) {
               console.log(error);
           }

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -1,0 +1,39 @@
+<!-- inline svg plugin -->
+
+<script>
+  (function() {
+      // /////////////////////////
+      // DESCRIPTION
+      // /////////////////////////
+
+      // This Manubot plugin fetches the text source code of SVGs in <img> tags,
+      // and inserts it into the document in place. This provides many
+      // advantages, such as being able to style SVGs globally from the CSS
+      // themes, and being able to make SVGs interactive with JavaScript and D3.
+
+      // /////////////////////////
+      // SCRIPT
+      // /////////////////////////
+
+      // start script
+      async function start() {
+          // get all <img> tags that have "src" attributes that end with ".svg"
+          const imgs = document.querySelectorAll('img[src$=".svg"]');
+          const inlineSvgs = Array.from(imgs).map(inlineSvg);
+          await Promise.all(inlineSvgs);
+
+          // dispatch "inline finished" event
+          // user d3 scripts should wait to hear this event before running
+          document.dispatchEvent(new Event('D3Loaded'));
+      }
+
+      // takes an svg <img> tag, fetches its source code, and replaces it 
+      async function inlineSvg(img) {
+        const text = await (await fetch(svg.src)).text();
+        svg.outerHTML = text;
+      }
+
+      // start script when document is finished loading
+      window.addEventListener('load', start);
+  })();
+</script>

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -30,7 +30,8 @@
       // takes an svg <img> tag, fetches its source code, and replaces it 
       async function inlineSvg(svg) {
         const text = await (await fetch(svg.src)).text();
-        svg.outerHTML = text;
+        if (text)
+            svg.outerHTML = text;
       }
 
       // start script when document is finished loading

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -11,6 +11,11 @@
       // advantages, such as being able to style SVGs globally from the CSS
       // themes, and being able to make SVGs interactive with JavaScript and D3.
 
+      // Note: This requires the page to be served from a server to work.
+      // See: https://stackoverflow.com/a/11063963/2180570
+      // Tip: Use the manubot commands to open the page in a local webserver
+      // See: https://github.com/manubot/rootstock#local-execution
+
       // /////////////////////////
       // SCRIPT
       // /////////////////////////
@@ -32,7 +37,7 @@
           try {
               // fetch svg source code
               const response = await fetch(img.src);
-              if (!response.ok) throw new Error('No SVG source')
+              if (!response.ok) throw new Error('Couldn\'t get SVG source')
               const source = await response.text();
               if (!source.trim()) throw new Error('No SVG source');
               // parse specifically as svg, create new (hidden) dom node

--- a/build/plugins/math.html
+++ b/build/plugins/math.html
@@ -1,4 +1,4 @@
-<!-- math plugin configuration -->
+<!-- mathjax plugin configuration -->
 
 <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
@@ -6,12 +6,16 @@
         "HTML-CSS": { linebreaks: { automatic: true } },
         "SVG": { linebreaks: { automatic: true } },
         "fast-preview": { disabled: true }
-    });
+  });
 </script>
 
-<!-- math plugin -->
+<!-- mathjax plugin -->
 
-<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'>
+<script
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-MML-AM_CHTML.js"
+    integrity="sha512-sRJwTwSmIAJfESgwGDn84X0s72u/n6qBjPShCGXi307x3ZFynu/u2A8652KZhmvjP0U0zeOFCxoMtj9imy9nOQ=="
+    crossorigin="anonymous"
+>
     // /////////////////////////
     // DESCRIPTION
     // /////////////////////////

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -216,7 +216,8 @@
     }
 
     /* figure image element */
-    figure img {
+    figure > img,
+    figure > svg {
         max-width: 100%;
         display: block;
         margin-left: auto;
@@ -1055,7 +1056,7 @@
 
     @media only screen {
         /* regular <img> in document when hovered */
-        .lightbox_document_img:hover {
+        img.lightbox_document_img:hover {
             cursor: pointer;
         }
 

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -225,7 +225,8 @@
     }
 
     /* figure auto-number */
-    img + figcaption > span:first-of-type {
+    img + figcaption > span:first-of-type,
+    svg + figcaption > span:first-of-type {
         font-weight: bold;
         margin-right: 5px;
     }
@@ -805,7 +806,8 @@
         }
 
         /* tooltip copy of <img> */
-        #tooltip_content > figure > img {
+        #tooltip_content > figure > img,
+        #tooltip_content > figure > svg {
             max-height: 260px;
         }
 


### PR DESCRIPTION
- adds plugin to "inline" svg img's (finds <img> tags with .svg src's, and replaces them in-place with the text source content of the svg)
- adds d3 plugin
- adds hash and other security attributes to mathjax plugin

Supercedes #373

A few notes:
- this wont work on local copies due to cross origin, but should fail gracefully, and not change the `<img>` if it can't load the source text. to test this PR, you'll have to run a local server, either with [the manubot commands](https://github.com/manubot/rootstock#local-execution) or this handy [chrome app](https://chrome.google.com/webstore/detail/web-server-for-chrome/ofhbbkphhbklhfoeikjpcbhemlocgigb/related?hl=en) 
- i've split these into two separate plugins, because they're really two separate concerns
- inserting the d3 script with javascript shouldn't be necessary because pandoc provides a way to insert things into the document
- we can use cleaner async/await because it's supported in all the browsers Manubot supports
- changed some things to be more consistent with the other plugins (use of `let`/`const` instead of `var`, comments at top of file, etc)
- checking for `data` attribute is unnecessary because we're only querying for `<img>`'s, not `<object>`'s
- getting `<img>` whose `src` attribute ends in `.svg` can all be done as a CSS selector
- using d3's filter and each functions is unnecessary because javascript built-in funcs will do fine. this way the plugins can be separate, too
- from my testing and from numerous of online examples, the`d3.js` source `<script>` tag can be in the `<head>` or `<body>`, as long as it comes before the code that uses d3. thus, i'm including the d3 plugin before the body. 
- no "onload" event listener of the d3 library is needed. but in our case, we're also doing our own asynchronous processing, to inline the svgs, so any code that relies on inlined svgs will have to wait until a `D3Loaded` event is triggered
- in order to transfer over attributes from the original image to the new SVG, we must parse the svg with a `DOMParser` rather than use `outerHTML`. idk why this is, but i dont think you can set additional attributes of an element after setting its `outerHTML`. anyway, this has the added benefit of checking to see if it's valid svg syntaxt too, rather than blindly copy/pasting its source into the document