### PR TITLE
Output manuscript-rendered.md with pandoc markdown

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -35,6 +35,12 @@ pandoc --verbose \
   --defaults=common.yaml \
   --defaults=html.yaml
 
+echo >&2 "Exporting Markdown manuscript"
+pandoc --verbose \
+  --data-dir="$PANDOC_DATA_DIR" \
+  --defaults=common.yaml \
+  --defaults=markdown.yaml
+
 # Set DOCKER_RUNNING to a non-empty string if docker is running, otherwise null.
 DOCKER_RUNNING="$(docker info &> /dev/null && echo "yes" || true)"
 

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -22,10 +22,10 @@ dependencies:
     - git+https://github.com/manubot/manubot@31968197d1ccd96a46bf092cdba4b575764bb954
     - opentimestamps-client==0.7.0
     - opentimestamps==0.4.1
-    - pandoc-eqnos==2.1.1
-    - pandoc-fignos==2.2.0
-    - pandoc-tablenos==2.1.1
-    - pandoc-xnos==2.2.0
+    - pandoc-eqnos==2.3.0
+    - pandoc-fignos==2.3.1
+    - pandoc-tablenos==2.2.2
+    - pandoc-xnos==2.4.3
     - pybase62==0.4.3
     - pysha3==1.0.2
     - python-bitcoinlib==0.10.2

--- a/build/pandoc/defaults/markdown.yaml
+++ b/build/pandoc/defaults/markdown.yaml
@@ -1,0 +1,4 @@
+# Pandoc --defaults for Pandoc markdown output.
+# Load on top of common defaults.
+to: markdown
+output-file: output/manuscript-rendered.md


### PR DESCRIPTION
Helps with https://github.com/manubot/rootstock/issues/381.

Runs common filters and produces markdown output that should be portable to other Pandoc systems like Rmarkdown.