### PR TITLE
CI: upgrade to conda-incubator/setup-miniconda@v2

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ci-cache-refs/heads/master
       - name: Install Environment
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: manubot
           environment-file: build/environment.yml


### PR DESCRIPTION
closes https://github.com/manubot/rootstock/issues/388

> The `set-env` command is deprecated and will be disabled on
November 16th. Please upgrade to using Environment Files.
For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/