### PR TITLE
update scite plugin

### DIFF
--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -23,7 +23,7 @@ include-after-body:
 - build/plugins/analytics.html
 - build/plugins/hypothesis.html
 - build/plugins/mathjax.html
-#- build/plugins/scite.html
+- build/plugins/scite.html
 variables:
   math: ""
 html-math-method:

--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -23,7 +23,7 @@ include-after-body:
 - build/plugins/analytics.html
 - build/plugins/hypothesis.html
 - build/plugins/mathjax.html
-- build/plugins/scite.html
+# - build/plugins/scite.html
 variables:
   math: ""
 html-math-method:

--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -23,7 +23,7 @@ include-after-body:
 - build/plugins/analytics.html
 - build/plugins/hypothesis.html
 - build/plugins/mathjax.html
-# - build/plugins/scite.html
+#- build/plugins/scite.html
 variables:
   math: ""
 html-math-method:

--- a/build/plugins/scite.html
+++ b/build/plugins/scite.html
@@ -14,7 +14,7 @@
 <script>
   // start script
   function start() {
-    // if printing, exit and don't show badges
+    // if printing, exit and don't run badges
     if (window.matchMedia("print").matches) return;
 
     // get citation elements
@@ -52,5 +52,11 @@
   .scite-badge {
     text-indent: 0;
     margin-top: 10px;
+  }
+
+  @media print {
+    .scite-badge {
+      display: none;
+    }
   }
 </style>

--- a/build/plugins/scite.html
+++ b/build/plugins/scite.html
@@ -5,11 +5,6 @@
   See https://scite.ai/.
 -->
 
-<link
-  rel="stylesheet"
-  type="text/css"
-  href="https://cdn.scite.ai/badge/scite-badge-latest.min.css"
-/>
 <script
   async
   type="application/javascript"
@@ -19,13 +14,13 @@
 <script>
   // start script
   function start() {
+    // if printing, exit and don't show badges
+    if (window.matchMedia("print").matches) return;
+
     // get citation elements
     const query = ".references div[id*='ref-']";
     const elements = document.querySelectorAll(query);
     for (const element of elements) addBadge(element);
-
-    // attach scroll listener to window
-    window.addEventListener("scroll", onScroll);
   }
 
   // add badge in citation element


### PR DESCRIPTION
- removed css include (scite authors recently pushed update that includes the css in the js)
- remove vestigial `onscroll` cruft
- add js "media query" check to abort the script when printing (though it doesn't work in athena, it should work it whatever we switch to). this can prevent timeouts in contexts like appveyor where it seems to wait forever for the scite lookups to return
- add css to hide badges on print (should work in athena, but js still runs)