### PR TITLE
Setup script

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -32,21 +32,25 @@ Windows setup requires [Git Bash](https://gitforwindows.org/) or [Windows Subsys
 Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script](https://github.com/manubot/rootstock/setup.bash).
 This simply runs the steps detailed below in the manual configuration.
 
-First, you must manually create an empty GitHub repository at <https://github.com/new>.
-Do not initialize the repository, other than optionally adding a Description.
-
-Next, run the command below.
-This will copy `setup.bash` and run it.
+Use the command below to copy `setup.bash` and run it.
 You can check the code that will be executed [here](https://github.com/manubot/rootstock/setup.bash).
 
-Replace `OWNER` and `REPO` details for your manuscript repo location:
-i.e. `https://github.com/OWNER/REPO`.
+````sh
+bash <( curl https://raw.githubusercontent.com/manubot/rootstock/main/setup.bash )
+````
+The script will then take you through the process of cloning the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
+Your new manuscript repo is then ready for you to start adding your own content.
+
+This script does not not create the remote repo for you, so you will be prompted to manually create an empty GitHub repository at <https://github.com/new>.
+Do not initialize the repository, other than optionally adding a description.
+
+### CLI
+There is also a command line interface for users who want to create manuscripts at scale and in an automated way.
+See the help for details.
 
 ````sh
-bash <( curl https://raw.githubusercontent.com/manubot/rootstock/main/setup.bash ) -o OWNER -r REPO
+bash setup.bash --help
 ````
-The script will then clone the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
-Your new manuscript repo is now ready for you to start adding your own content.
 
 ## Manual configuration
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -36,7 +36,7 @@ Use the command below to copy `setup.bash` and run it.
 You can check the code that will be executed [here](https://github.com/manubot/rootstock/setup.bash).
 
 ````sh
-bash <( curl https://raw.githubusercontent.com/manubot/rootstock/main/setup.bash )
+bash <( curl https://github.com/manubot/rootstock/raw/main/setup.bash )
 ````
 The script will then take you through the process of cloning the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
 Your new manuscript repo is then ready for you to start adding your own content.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,7 +1,8 @@
 # Table of contents
 
 - [Creating a new manuscript](#creating-a-new-manuscript)
-  * [Configuration](#configuration)
+  * [Using setup script](#using-setup-script)
+  * [Manual Configuration](#manual-configuration)
   * [Create repository](#create-repository)
   * [Continuous integration](#continuous-integration)
     + [GitHub Actions](#github-actions)
@@ -27,7 +28,26 @@ These steps should be performed in a command-line shell (terminal), starting in 
 Setup is supported on Linux, macOS, and Windows.
 Windows setup requires [Git Bash](https://gitforwindows.org/) or [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-## Configuration
+## Using setup script
+Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script]((https://github.com/manubot/rootstock/setup.bash). This simply runs the steps detailed below in the Manual Configuration.
+
+First, you must manually create an empty GitHub repository at <https://github.com/new>.
+Do not initialize the repository, other than optionally adding a Description.
+
+Next, copy `setup.bash` to the directory where you would like to clone your manuscript repo, then make it executable.
+
+Then run the script using the `OWNER` and `REPO` details for your manuscript repo location:
+i.e. `https://github.com/OWNER/REPO`.
+
+````sh
+# Make script executable
+chmod +x setup.bash
+# Run script with your repo details as arguments
+./setup.bash -o OWNER -r REPO
+````
+The script will then clone the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
+
+## Manual Configuration
 
 First, you must configure two environment variables (`OWNER` and `REPO`).
 These variables specify the GitHub repository for the manuscript (i.e. `https://github.com/OWNER/REPO`).

--- a/SETUP.md
+++ b/SETUP.md
@@ -45,6 +45,7 @@ bash <( curl https://raw.githubusercontent.com/manubot/rootstock/main/setup.bash
 ````
 The script will then clone the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
 The repo is now ready for you to start adding your own content.
+
 ## Manual Configuration
 
 First, you must configure two environment variables (`OWNER` and `REPO`).

--- a/SETUP.md
+++ b/SETUP.md
@@ -34,26 +34,17 @@ Creating a new manuscript using GitHub actions, the recommended default CI servi
 First, you must manually create an empty GitHub repository at <https://github.com/new>.
 Do not initialize the repository, other than optionally adding a Description.
 
-Next, copy `setup.bash` to the directory where you would like to clone your manuscript repo, then make it executable.
+Next, run ths command below. This will copy `setup.bash` and run it.
+You can check the code that will be executed [here](https://github.com/manubot/rootstock/setup.bash).
 
-Then run the script using the `OWNER` and `REPO` details for your manuscript repo location:
+Replace `OWNER` and `REPO` details for your manuscript repo location:
 i.e. `https://github.com/OWNER/REPO`.
 
 ````sh
-# create file in dir to contain the manuscript repo
-touch setup.bash
-
-# Use your favourite editor to copy and paste in the
-# contents of https://github.com/manubot/rootstock/setup.bash
-
-# Make script executable
-chmod +x setup.bash
-
-# Run script with your repo details as arguments
-./setup.bash -o OWNER -r REPO
+bash <( curl https://raw.githubusercontent.com/manubot/rootstock/main/setup.bash ) -o OWNER -r REPO
 ````
 The script will then clone the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
-
+The repo is now ready for you to start adding your own content.
 ## Manual Configuration
 
 First, you must configure two environment variables (`OWNER` and `REPO`).

--- a/SETUP.md
+++ b/SETUP.md
@@ -29,7 +29,7 @@ Setup is supported on Linux, macOS, and Windows.
 Windows setup requires [Git Bash](https://gitforwindows.org/) or [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
 ## Using setup script
-Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script]((https://github.com/manubot/rootstock/setup.bash). This simply runs the steps detailed below in the Manual Configuration.
+Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script](https://github.com/manubot/rootstock/setup.bash). This simply runs the steps detailed below in the Manual Configuration.
 
 First, you must manually create an empty GitHub repository at <https://github.com/new>.
 Do not initialize the repository, other than optionally adding a Description.
@@ -40,8 +40,15 @@ Then run the script using the `OWNER` and `REPO` details for your manuscript rep
 i.e. `https://github.com/OWNER/REPO`.
 
 ````sh
+# create file in dir to contain the manuscript repo
+touch setup.bash
+
+# Use your favourite editor to copy and paste in the
+# contents of https://github.com/manubot/rootstock/setup.bash
+
 # Make script executable
 chmod +x setup.bash
+
 # Run script with your repo details as arguments
 ./setup.bash -o OWNER -r REPO
 ````

--- a/SETUP.md
+++ b/SETUP.md
@@ -29,11 +29,11 @@ Setup is supported on Linux, macOS, and Windows.
 Windows setup requires [Git Bash](https://gitforwindows.org/) or [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
 ## Using setup script
-Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script](https://github.com/manubot/rootstock/setup.bash).
+Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script](https://github.com/manubot/rootstock/blob/main/setup.bash).
 This simply runs the steps detailed below in the manual configuration.
 
 Use the command below to copy `setup.bash` and run it.
-You can check the code that will be executed [here](https://github.com/manubot/rootstock/setup.bash).
+You can check the code that will be executed [here](https://github.com/manubot/rootstock/blob/main/setup.bash).
 
 ````sh
 bash <( curl --location https://github.com/manubot/rootstock/raw/main/setup.bash )
@@ -54,6 +54,7 @@ bash setup.bash --help
 
 ## Manual configuration
 
+If you do not wish to use the above setup script to configure your new manuscript repository, you can instead execute the steps manually.
 First, you must configure two environment variables (`OWNER` and `REPO`).
 These variables specify the GitHub repository for the manuscript (i.e. `https://github.com/OWNER/REPO`).
 Make sure that the case of `OWNER` matches how your username is displayed on GitHub.

--- a/SETUP.md
+++ b/SETUP.md
@@ -36,7 +36,7 @@ Use the command below to copy `setup.bash` and run it.
 You can check the code that will be executed [here](https://github.com/manubot/rootstock/setup.bash).
 
 ````sh
-bash <( curl https://github.com/manubot/rootstock/raw/main/setup.bash )
+bash <( curl --location https://github.com/manubot/rootstock/raw/main/setup.bash )
 ````
 The script will then take you through the process of cloning the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
 Your new manuscript repo is then ready for you to start adding your own content.

--- a/SETUP.md
+++ b/SETUP.md
@@ -2,7 +2,7 @@
 
 - [Creating a new manuscript](#creating-a-new-manuscript)
   * [Using setup script](#using-setup-script)
-  * [Manual Configuration](#manual-configuration)
+  * [Manual configuration](#manual-configuration)
   * [Create repository](#create-repository)
   * [Continuous integration](#continuous-integration)
     + [GitHub Actions](#github-actions)
@@ -29,12 +29,14 @@ Setup is supported on Linux, macOS, and Windows.
 Windows setup requires [Git Bash](https://gitforwindows.org/) or [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
 ## Using setup script
-Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script](https://github.com/manubot/rootstock/setup.bash). This simply runs the steps detailed below in the Manual Configuration.
+Creating a new manuscript using GitHub actions, the recommended default CI service (see below), can be achieved easily using the [setup script](https://github.com/manubot/rootstock/setup.bash).
+This simply runs the steps detailed below in the manual configuration.
 
 First, you must manually create an empty GitHub repository at <https://github.com/new>.
 Do not initialize the repository, other than optionally adding a Description.
 
-Next, run ths command below. This will copy `setup.bash` and run it.
+Next, run the command below.
+This will copy `setup.bash` and run it.
 You can check the code that will be executed [here](https://github.com/manubot/rootstock/setup.bash).
 
 Replace `OWNER` and `REPO` details for your manuscript repo location:
@@ -44,9 +46,9 @@ i.e. `https://github.com/OWNER/REPO`.
 bash <( curl https://raw.githubusercontent.com/manubot/rootstock/main/setup.bash ) -o OWNER -r REPO
 ````
 The script will then clone the rootstock repo, make the changes required to use GitHub actions, edit the README to point to your repo and commit the changes.
-The repo is now ready for you to start adding your own content.
+Your new manuscript repo is now ready for you to start adding your own content.
 
-## Manual Configuration
+## Manual configuration
 
 First, you must configure two environment variables (`OWNER` and `REPO`).
 These variables specify the GitHub repository for the manuscript (i.e. `https://github.com/OWNER/REPO`).

--- a/setup.bash
+++ b/setup.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Setup Manubot
 # Based on https://github.com/manubot/rootstock/blob/main/SETUP.md
-# This is designed to be run from the terminal on linux
+# This is designed to be run from the bash terminal
 
 # Stop on first error.
 set -e
@@ -165,7 +165,7 @@ if [[ "$YES" == '0' ]]; then
   while true
   do
    echo
-   read -r -p "Would you like to use SSH to authenticate your GitHub account? [y/n]" input
+   read -r -p "Would you like to use SSH to authenticate your GitHub account? [y/n] " input
 
    case $input in
      [yY][eE][sS]|[yY])

--- a/setup.bash
+++ b/setup.bash
@@ -6,15 +6,44 @@
 # Stop on first error.
 set -e
 
-usage() { echo "Usage: $0 [-o <owner-string>] [-r <repo-string>]" 1>&2; exit 1; }
+usage() {
+echo "Usage: $0 [--owner <owner-string>] [--repo <repo-string>]"
+echo "Replace OWNER and REPO details for your manuscript repo location:"
+echo "i.e. https://github.com/OWNER/REPO."
+1>&2; exit 1; }
 
-# Get the repo name.
-while getopts o:r: flag
-do
-    case "${flag}" in
-        o) OWNER=${OPTARG};;
-        r) REPO=${OPTARG};;
-    esac
+# Option strings
+SHORT=o:r:
+LONG=owner:,repo:
+
+# read the options
+OPTS=$(getopt --options $SHORT --long $LONG --name "$0" -- "$@")
+
+if [ $? != 0 ] ; then echo "Failed to parse options...exiting." >&2 ; exit 1 ; fi
+
+eval set -- "$OPTS"
+
+# extract options and their arguments into variables.
+while true ; do
+  case "$1" in
+    -o | --owner )
+      shift;
+      OWNER=$1
+      shift
+      ;;
+    -r | --repo )
+      REPO="$2"
+      shift 2
+      ;;
+    -- )
+      shift
+      break
+      ;;
+    *)
+      echo "Internal error!"
+      exit 1
+      ;;
+  esac
 done
 
 if [ -z "${OWNER}" ] || [ -z "${REPO}" ]; then

--- a/setup.bash
+++ b/setup.bash
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Setup Manubot
+# Based on https://github.com/manubot/rootstock/blob/main/SETUP.md
+# This is designed to be run from the terminal on linux
+
+# Stop on first error.
+set -e
+
+usage() { echo "Usage: $0 [-o <owner-string>] [-r <repo-string>]" 1>&2; exit 1; }
+
+# Get the repo name.
+while getopts o:r: flag
+do
+    case "${flag}" in
+        o) OWNER=${OPTARG};;
+        r) REPO=${OPTARG};;
+    esac
+done
+
+if [ -z "${OWNER}" ] || [ -z "${REPO}" ]; then
+    usage
+fi
+
+# Check Remote Repo Exists.
+echo
+while true
+do
+ read -r -p "Have you manually created https://github.com/${OWNER}/${REPO}? [y/n] " input
+
+ case $input in
+     [yY][eE][sS]|[yY])
+
+ echo
+ echo "Continuing Setup..."
+ echo
+ break
+ ;;
+     [nN][oO]|[nN])
+ echo
+ echo "Go to https://github.com/new and create https://github.com/${OWNER}/${REPO}"
+ echo "Note: the new repo must be completely empty or the script will fail."
+ echo
+ break
+        ;;
+     *)
+ echo
+ echo "Invalid input, try again..."
+ echo
+ ;;
+ esac
+done
+
+# Clone manubot/rootstock
+echo
+echo "Cloning Rootstock..."
+echo
+git clone --single-branch https://github.com/manubot/rootstock.git ${REPO}
+cd ${REPO}
+
+echo
+echo "Setup tracking using https..."
+echo
+# Configure remotes
+git remote add rootstock https://github.com/manubot/rootstock.git
+# Option A: Set origin URL using its web address
+git remote set-url origin https://github.com/${OWNER}/${REPO}.git
+
+git push --set-upstream origin main
+
+# To use GitHub Actions only:
+echo "Setup for GitHub Actions ONLY..."
+# remove Travis CI config
+git rm .travis.yml
+# remove AppVeyor config
+git rm .appveyor.yml
+# remove ci/install.sh if using neither Travis CI nor AppVeyor
+git rm ci/install.sh
+
+# Update README
+echo "Updating README..."
+# Perform substitutions
+sed "s/manubot\/rootstock/${OWNER}\/${REPO}/g" README.md > tmp && mv -f tmp README.md
+sed "s/manubot\.github\.io\/rootstock/${OWNER}\.github\.io\/${REPO}/g" README.md > tmp && mv -f tmp README.md
+
+echo "Committing rebrand..."
+git add --update
+git commit --message "Brand repo to $OWNER/$REPO"
+git push origin main
+echo
+echo "Setup complete"
+echo
+echo "The new repo as been created here: $(pwd)/${REPO}"
+echo
+echo "A good first step is to modify content/metadata.yaml with the relevant information for your manuscript."
+echo

--- a/setup.bash
+++ b/setup.bash
@@ -224,7 +224,7 @@ git push origin main
 echo
 echo "Setup complete"
 echo
-echo "The new repo as been created here: $(pwd)/${REPO}"
+echo "The new repo has been created at $(pwd)"
 echo
 echo "A good first step is to modify content/metadata.yaml with the relevant information for your manuscript."
 echo

--- a/setup.bash
+++ b/setup.bash
@@ -7,9 +7,18 @@
 set -e
 
 usage() {
-echo "Usage: $0 [--owner <owner-string>] [--repo <repo-string>]"
-echo "Replace OWNER and REPO details for your manuscript repo location:"
+echo "Usage: $0 [--owner text] [--repo text] [--yes]"
+echo "Guides the user through the creation of a new Manubot repository for their manuscript."
+echo
+echo "If no options are supplied a fully interactive process is used."
+echo "OWNER and REPO refer to the details of your manuscript repo location:"
 echo "i.e. https://github.com/OWNER/REPO."
+echo
+echo "Options:"
+echo "  -o --owner   GitHub user or organisation name."
+echo "  -r --repo    Name of the repository for your new manuscript."
+echo "  -y --yes     Continue script without asking for confirmation that the repo exists."
+echo "  -h --help    Display usage information."
 1>&2; exit 1; }
 
 # Check if to continue

--- a/setup.bash
+++ b/setup.bash
@@ -28,25 +28,25 @@ do
  read -r -p "Have you manually created https://github.com/${OWNER}/${REPO}? [y/n] " input
 
  case $input in
-     [yY][eE][sS]|[yY])
+   [yY][eE][sS]|[yY])
 
- echo
- echo "Continuing Setup..."
- echo
- break
- ;;
-     [nN][oO]|[nN])
- echo
- echo "Go to https://github.com/new and create https://github.com/${OWNER}/${REPO}"
- echo "Note: the new repo must be completely empty or the script will fail."
- echo
- break
-        ;;
-     *)
- echo
- echo "Invalid input, try again..."
- echo
- ;;
+     echo
+     echo "Continuing Setup..."
+     echo
+     break
+     ;;
+  [nN][oO]|[nN])
+     echo
+     echo "Go to https://github.com/new and create https://github.com/${OWNER}/${REPO}"
+     echo "Note: the new repo must be completely empty or the script will fail."
+     echo
+     exit 1
+     ;;
+  *)
+     echo
+     echo "Invalid input, try again..."
+     echo
+     ;;
  esac
 done
 

--- a/setup.bash
+++ b/setup.bash
@@ -12,9 +12,37 @@ echo "Replace OWNER and REPO details for your manuscript repo location:"
 echo "i.e. https://github.com/OWNER/REPO."
 1>&2; exit 1; }
 
+# Check if to continue
+check(){
+while true
+do
+ echo "Once you have created your repo press enter to continue setup,"
+ read -r -p "or type exit to quit now: " input
+
+ case $input in
+   "")
+     echo
+     echo "Continuing Setup..."
+     echo
+     break
+     ;;
+  [eE][xX][iI][tT])
+     exit 1
+     ;;
+  *)
+     echo
+     echo "Invalid input, try again..."
+     echo
+     ;;
+ esac
+done
+}
+
 # Option strings
-SHORT=o:r:
-LONG=owner:,repo:
+SHORT=o:r:hy
+LONG=owner:,repo:,help,yes
+
+YES=0
 
 # read the options
 OPTS=$(getopt --options $SHORT --long $LONG --name "$0" -- "$@")
@@ -35,9 +63,18 @@ while true ; do
       REPO="$2"
       shift 2
       ;;
+    -y | --yes )
+      YES=1
+      shift
+      ;;
     -- )
       shift
       break
+      ;;
+    -h | --help )
+      shift
+      usage
+      exit 1
       ;;
     *)
       echo "Internal error!"
@@ -47,37 +84,52 @@ while true ; do
 done
 
 if [ -z "${OWNER}" ] || [ -z "${REPO}" ]; then
-    usage
+  echo "This script will take you through the setup process for Manubot."
+  echo "First, we need to specify where to create the GitHub repo for your manuscript."
+  echo
+  echo "The URL will take this format: https://github.com/OWNER/REPO."
+  echo "OWNER is your username or organisation"
+  echo "REPO is the name of your repository"
+  echo
+  read -r -p "Type in the OWNER now:" input
+  OWNER=$input
+  read -r -p "Type in the REPO now:" input
+  REPO=$input
 fi
 
-# Check Remote Repo Exists.
-echo
-while true
-do
- read -r -p "Have you manually created https://github.com/${OWNER}/${REPO}? [y/n] " input
+# If using interactive mode, check remote repo exists.
+if [[ "$YES" == '0' ]]; then
+  while true
+  do
+   echo
+   read -r -p "Have you manually created https://github.com/${OWNER}/${REPO}? [y/n] " input
 
- case $input in
-   [yY][eE][sS]|[yY])
+   case $input in
+     [yY][eE][sS]|[yY])
 
-     echo
-     echo "Continuing Setup..."
-     echo
-     break
-     ;;
-  [nN][oO]|[nN])
-     echo
-     echo "Go to https://github.com/new and create https://github.com/${OWNER}/${REPO}"
-     echo "Note: the new repo must be completely empty or the script will fail."
-     echo
-     exit 1
-     ;;
-  *)
-     echo
-     echo "Invalid input, try again..."
-     echo
-     ;;
- esac
-done
+       echo
+       echo "Continuing Setup..."
+       echo
+       break
+       ;;
+    [nN][oO]|[nN])
+       echo
+       echo "Go to https://github.com/new and create https://github.com/${OWNER}/${REPO}"
+       echo "Note: the new repo must be completely empty or the script will fail."
+       echo
+       check
+       break
+       ;;
+    *)
+       echo
+       echo "Invalid input, try again..."
+       echo
+       ;;
+   esac
+  done
+else
+  echo "Setting up https://github.com/${OWNER}/${REPO}"
+fi
 
 # Clone manubot/rootstock
 echo


### PR DESCRIPTION
I wanted to make a couple of manuscript repos and also wanted it to be as easy as possible to convince the rest of my team that this is the tool we should use to write papers, so I wrote a setup script. 

It takes the "Intermediate step" from #401 where the users manually create an empty repo and the script does the rest. 
This seems the most user-friendly route, even if it is not the most automated. 