### PR TITLE
add ability to collapse section by default, prioritize attr plugin load

### DIFF
--- a/build/plugins/accordion.html
+++ b/build/plugins/accordion.html
@@ -19,7 +19,8 @@
       // start expanded/collapsed based on option
       if (
         startCollapsed === "true" ||
-        (startCollapsed === "auto" && isSmallScreen())
+        (startCollapsed === "auto" && isSmallScreen()) ||
+        heading.dataset.collapsed === "true"
       )
         collapseHeading(heading);
       else expandElement(heading);

--- a/build/plugins/attributes.html
+++ b/build/plugins/attributes.html
@@ -79,6 +79,7 @@
     }
   }
 
-  // start script when document is finished loading
-  window.addEventListener("load", start);
+  // start script on DOMContentLoaded instead of load to ensure this plugins
+  // runs before other plugins
+  window.addEventListener("DOMContentLoaded", start);
 </script>

--- a/build/plugins/hypothesis.html
+++ b/build/plugins/hypothesis.html
@@ -4,7 +4,7 @@
   Allows public annotation of the  manuscript. See https://web.hypothes.is/.
 -->
 
-<script>
+<script type="module">
   // configuration
   window.hypothesisConfig = function () {
     return {

--- a/build/plugins/scite.html
+++ b/build/plugins/scite.html
@@ -11,7 +11,7 @@
   src="https://cdn.scite.ai/badge/scite-badge-latest.min.js"
 ></script>
 
-<script>
+<script type="module">
   // start script
   function start() {
     // if printing, exit and don't run badges


### PR DESCRIPTION
Make a few minor fixes learned from https://github.com/greenelab/covid19-review/pull/1036

- add ability to collapse heading 2 section by default using attributes plugin
- run attributes plugin before other plugins to ensure the above works, and to possibly prevent future errors
- locally scope hypothesis and scite plugin scripts