### PR TITLE
build: MANUBOT_USE_DOCKER environment variable

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,12 +11,17 @@ export TZ=Etc/UTC
 # Default Python to read/write text files using UTF-8 encoding
 export LC_ALL=en_US.UTF-8
 
+
+# Set DOCKER_RUNNING to true if docker is running, otherwise false.
+DOCKER_RUNNING="$(docker info &> /dev/null && echo "true" || (true && echo "false"))"
+
 # Set option defaults
 CI="${CI:-false}"
 BUILD_PDF="${BUILD_PDF:-true}"
 BUILD_DOCX="${BUILD_DOCX:-false}"
 BUILD_LATEX="${BUILD_LATEX:-false}"
 SPELLCHECK="${SPELLCHECK:-false}"
+MANUBOT_USE_DOCKER="${MANUBOT_USE_DOCKER:-$DOCKER_RUNNING}"
 # Pandoc's configuration is specified via files of option defaults
 # located in the $PANDOC_DATA_DIR/defaults directory.
 PANDOC_DATA_DIR="${PANDOC_DATA_DIR:-build/pandoc}"
@@ -41,13 +46,10 @@ pandoc --verbose \
   --defaults=common.yaml \
   --defaults=html.yaml
 
-# Set DOCKER_RUNNING to a non-empty string if docker is running, otherwise null.
-DOCKER_RUNNING="$(docker info &> /dev/null && echo "yes" || true)"
-
 # Create PDF output (unless BUILD_PDF environment variable equals "false")
 # The double-commas (,,) lowercase the variable.
 # If Docker is not available, use WeasyPrint to create PDF
-if [ "${BUILD_PDF,,}" != "false" ] && [ -z "$DOCKER_RUNNING" ]; then
+if [ "${BUILD_PDF,,}" != "false" ] && [ "${MANUBOT_USE_DOCKER,,}" != "true" ]; then
   echo >&2 "Exporting PDF manuscript using WeasyPrint"
   if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
   ln -s content/images
@@ -60,7 +62,7 @@ if [ "${BUILD_PDF,,}" != "false" ] && [ -z "$DOCKER_RUNNING" ]; then
 fi
 
 # If Docker is available, use athenapdf to create PDF
-if [ "${BUILD_PDF,,}" != "false" ] && [ -n "$DOCKER_RUNNING" ]; then
+if [ "${BUILD_PDF,,}" != "false" ] && [ "${MANUBOT_USE_DOCKER,,}" == "true" ]; then
   echo >&2 "Exporting PDF manuscript using Docker + Athena"
   if [ "${CI,,}" = "true" ]; then
     # Incease --delay for CI builds to ensure the webpage fully renders, even when the CI server is under high load.


### PR DESCRIPTION
closes https://github.com/manubot/rootstock/issues/440

`MANUBOT_USE_DOCKER=true` instructs Manubot to use Docker for PDF export. Defaults to `DOCKER_RUNNING` (whether Docker is running on the system).