### PR TITLE
CI: use miniforge instead of miniconda

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -63,7 +63,7 @@ jobs:
           activate-environment: manubot
           environment-file: build/environment.yml
           auto-activate-base: false
-          miniconda-version: 'latest'
+          miniforge-version: 'latest'
       - name: Install Spellcheck
         shell: bash --login {0}
         run: |

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,9 +7,9 @@
 set -o errexit \
     -o pipefail
 
-wget https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh \
-    --output-document miniconda.sh
-bash miniconda.sh -b -p $HOME/miniconda
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-$(uname)-$(uname -m).sh \
+  --output-document miniforge.sh
+bash miniforge.sh -b -p $HOME/miniconda
 source $HOME/miniconda/etc/profile.d/conda.sh
 hash -r
 conda config \


### PR DESCRIPTION
This PR switches from the miniconda to miniforge installer for both GitHub Actions and AppVeyor. The difference between these installers [is](https://conda-forge.org/):

> Miniforge is an effort to provide Miniconda-like installers, with the added feature that conda-forge is the default channel. Unlike Miniconda, these support ARMv8 64-bit (formally known as `aarch64`).

I've always found using `conda-forge` as the default channel to be preferable. conda-forge is a community maintained project aligned with the ethos of manubot.

[Miniforge](https://github.com/conda-forge/miniforge) also makes it easy to switch to `mamba` instead of `conda` for installation should we want in the future.