### PR TITLE
CI: use github.event context for DEFAULT_BRANCH

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - master
+  # NOTE: scheduled workflows aren't supported
+  # https://github.community/t/github-event-repository-fork-context-does-detect-forks-in-scheduled-jobs/185925
   workflow_dispatch:
     inputs:
       BUILD_PDF:

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -46,7 +46,7 @@ jobs:
           TRIGGERING_SHA=${GITHUB_PULL_REQUEST_SHA:-$GITHUB_SHA}
           echo "TRIGGERING_SHA_7=${TRIGGERING_SHA::7}" >> $GITHUB_ENV
           echo "TRIGGERING_SHA: $TRIGGERING_SHA"
-          DEFAULT_BRANCH=$(git remote show origin | grep --perl-regexp --only-matching "(?<=HEAD branch: ).+")
+          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
           echo "DEFAULT_BRANCH=${DEFAULT_BRANCH}" >> $GITHUB_ENV
           echo "DEFAULT_BRANCH_REF=refs/heads/$DEFAULT_BRANCH" >> $GITHUB_ENV
           echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"


### PR DESCRIPTION
Updates method added in https://github.com/manubot/rootstock/pull/399. See commit notes from https://github.com/manubot/rootstock/pull/399/commits/667d170eb2f1898156226456292d25c1c99377c4 on references for the old method. I believe `github.event.repository.default_branch` did not exist when we initially implemented this.

One benefit is this removes a bash command that does not work on macos due to an old grep. Running CI on macos or windows is helpful for prototyping our environment.

## References

- https://stackoverflow.com/a/68414395/4651668