### PR TITLE
build.sh: remove bash lowercase substitution

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -47,9 +47,8 @@ pandoc --verbose \
   --defaults=html.yaml
 
 # Create PDF output (unless BUILD_PDF environment variable equals "false")
-# The double-commas (,,) lowercase the variable.
 # If Docker is not available, use WeasyPrint to create PDF
-if [ "${BUILD_PDF,,}" != "false" ] && [ "${MANUBOT_USE_DOCKER,,}" != "true" ]; then
+if [ "${BUILD_PDF}" != "false" ] && [ "${MANUBOT_USE_DOCKER}" != "true" ]; then
   echo >&2 "Exporting PDF manuscript using WeasyPrint"
   if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
   ln -s content/images
@@ -62,9 +61,9 @@ if [ "${BUILD_PDF,,}" != "false" ] && [ "${MANUBOT_USE_DOCKER,,}" != "true" ]; t
 fi
 
 # If Docker is available, use athenapdf to create PDF
-if [ "${BUILD_PDF,,}" != "false" ] && [ "${MANUBOT_USE_DOCKER,,}" == "true" ]; then
+if [ "${BUILD_PDF}" != "false" ] && [ "${MANUBOT_USE_DOCKER}" == "true" ]; then
   echo >&2 "Exporting PDF manuscript using Docker + Athena"
-  if [ "${CI,,}" = "true" ]; then
+  if [ "${CI}" = "true" ]; then
     # Incease --delay for CI builds to ensure the webpage fully renders, even when the CI server is under high load.
     # Local builds default to a shorter --delay to minimize runtime, assuming proper rendering is less crucial.
     MANUBOT_ATHENAPDF_DELAY="${MANUBOT_ATHENAPDF_DELAY:-5000}"
@@ -86,7 +85,7 @@ if [ "${BUILD_PDF,,}" != "false" ] && [ "${MANUBOT_USE_DOCKER,,}" == "true" ]; t
 fi
 
 # Create DOCX output (if BUILD_DOCX environment variable equals "true")
-if [ "${BUILD_DOCX,,}" = "true" ]; then
+if [ "${BUILD_DOCX}" = "true" ]; then
   echo >&2 "Exporting Word Docx manuscript"
   pandoc --verbose \
     --data-dir="$PANDOC_DATA_DIR" \
@@ -95,7 +94,7 @@ if [ "${BUILD_DOCX,,}" = "true" ]; then
 fi
 
 # Create LaTeX output (if BUILD_LATEX environment variable equals "true")
-if [ "${BUILD_LATEX,,}" = "true" ]; then
+if [ "${BUILD_LATEX}" = "true" ]; then
   echo >&2 "Exporting LaTeX manuscript"
   pandoc \
     --data-dir="$PANDOC_DATA_DIR" \
@@ -104,7 +103,7 @@ if [ "${BUILD_LATEX,,}" = "true" ]; then
 fi
 
 # Spellcheck
-if [ "${SPELLCHECK,,}" = "true" ]; then
+if [ "${SPELLCHECK}" = "true" ]; then
   export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt; ignore-case true"
 
   # Identify and store spelling errors


### PR DESCRIPTION
closes https://github.com/manubot/rootstock/issues/451

The `,,` operator was introduced in bash 4.0, but bash on macOS is still version 3.2