### PR TITLE
Update 00.front-matter.md

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -27,19 +27,26 @@ on {{manubot.date}}.
 
 {## Template for listing authors ##}
 {% for author in manubot.authors %}
-+ **{{author.name}}**<br>
++ **{{author.name}}** {% if author.correspondence is defined and author.correspondence == true -%}^[✉](#correspondence)^{%- endif -%}\
   {%- if author.orcid is defined and author.orcid is not none %}
     ![ORCID icon](images/orcid.svg){.inline_icon width=16 height=16}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
+    {%- if author.github is not defined or author.github is none and author.twitter is not defined or author.twitter is none %}
+      \
+    {%- endif %}
   {%- endif %}
   {%- if author.github is defined and author.github is not none %}
     · ![GitHub icon](images/github.svg){.inline_icon width=16 height=16}
     [{{author.github}}](https://github.com/{{author.github}})
+    {%- if author.twitter is not defined or author.twitter is none %}
+      \
+    {%- endif %}
   {%- endif %}
   {%- if author.twitter is defined and author.twitter is not none %}
     · ![Twitter icon](images/twitter.svg){.inline_icon width=16 height=16}
     [{{author.twitter}}](https://twitter.com/{{author.twitter}})
-  {%- endif %}<br>
+    \
+  {%- endif %}
   <small>
   {%- if author.affiliations is defined and author.affiliations|length %}
      {{author.affiliations | join('; ')}}


### PR DESCRIPTION
Hi,

While converting manuscripts to other formats through pandoc (for example ePub), I realized `<br>` causes some issues. Therefore, `\` is preferable over `<br>`. (see https://pandoc.org/MANUAL.html#extension-escaped_line_breaks)

I added some if statements to avoid incorrect linebreaks depending on author's information.

Also took the opportunity to add correspondence as default

Best,