### PR TITLE
Adding pandoc-secnos to the build environment.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -76,6 +76,11 @@ For example, the following will override the figure number to be "S1" and set th
 
 We recommend always specifying the width of SVG images (even if just `width="100%"`), since otherwise SVGs may not render properly in the [WeasyPrint](https://weasyprint.org/) PDF export.
 
+### Sections
+
+Manubot supports section references, as provided by the [`pandoc-secnos`](https://github.com/tomduck/pandoc-secnos) library.
+Adding an anchor to a section header with `{#sec:section-name}` makes it available for citation using `@sec:section-name` inline in the text.
+
 ### Citations
 
 Manubot supports [Pandoc citations](https://pandoc.org/MANUAL.html#citations), but with added support for citing persistent identifiers directly.

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -26,6 +26,7 @@ dependencies:
     - opentimestamps==0.4.1
     - pandoc-eqnos==2.5.0
     - pandoc-fignos==2.4.0
+    - pandoc-secnos==2.2.2
     - pandoc-tablenos==2.3.0
     - pandoc-xnos==2.5.0
     - pandocfilters==1.5.0

--- a/build/pandoc/defaults/common.yaml
+++ b/build/pandoc/defaults/common.yaml
@@ -4,6 +4,7 @@ input-file: output/manuscript.md
 filters:
 - pandoc-fignos
 - pandoc-eqnos
+- pandoc-secnos
 - pandoc-tablenos
 - pandoc-manubot-cite
 - citeproc


### PR DESCRIPTION
In conjunction with https://github.com/manubot/manubot/pull/334 , this makes it possible to add section references to a manuscript.  I have not updated the github hash for manubot referenced in the build environment, but will if/when that pull request is accepted.

A sample build of this is now in the [yt paper build](https://yt-project.github.io/yt-4.0-paper/#selection-routines) where you can see the number of sections referenced.  I did note that all the sections are part of part 1, which I suspect might be an issue with the fact that I seem to be using `##` as the base section number.  That's probably fixable somehow on our end.
