### PR TITLE
Fix author list when no author metadata is present

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -30,19 +30,23 @@ on {{manubot.date}}.
 + **{{author.name}}**
   {% if author.corresponding is defined and author.corresponding == true -%}^[✉](#correspondence)^{%- endif -%}
   <br>
-  {%- if author.orcid is defined and author.orcid is not none %} {% set line1 = true %}
+  {%- set has_ids = false %}
+  {%- if author.orcid is defined and author.orcid is not none %}
+  {%- set has_ids = true %}
     ![ORCID icon](images/orcid.svg){.inline_icon width=16 height=16}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
   {%- endif %}
-  {%- if author.github is defined and author.github is not none %} {% set line1 = true %}
+  {%- if author.github is defined and author.github is not none %}
+    {%- set has_ids = true %}
     · ![GitHub icon](images/github.svg){.inline_icon width=16 height=16}
     [{{author.github}}](https://github.com/{{author.github}})
   {%- endif %}
-  {%- if author.twitter is defined and author.twitter is not none %} {% set line1 = true %}
+  {%- if author.twitter is defined and author.twitter is not none %}
+    {%- set has_ids = true %}
     · ![Twitter icon](images/twitter.svg){.inline_icon width=16 height=16}
     [{{author.twitter}}](https://twitter.com/{{author.twitter}})
   {%- endif %}
-  {%- if line1 is defined and line1 == true %}
+  {%- if has_ids == true %}
     <br>
   {%- endif %}
   <small>

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -32,7 +32,7 @@ on {{manubot.date}}.
   <br>
   {%- set has_ids = false %}
   {%- if author.orcid is defined and author.orcid is not none %}
-  {%- set has_ids = true %}
+    {%- set has_ids = true %}
     ![ORCID icon](images/orcid.svg){.inline_icon width=16 height=16}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
   {%- endif %}

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -46,7 +46,7 @@ on {{manubot.date}}.
     · ![Twitter icon](images/twitter.svg){.inline_icon width=16 height=16}
     [{{author.twitter}}](https://twitter.com/{{author.twitter}})
   {%- endif %}
-  {%- if has_ids == true %}
+  {%- if has_ids %}
     <br>
   {%- endif %}
   <small>

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -30,18 +30,21 @@ on {{manubot.date}}.
 + **{{author.name}}**
   {% if author.corresponding is defined and author.corresponding == true -%}^[✉](#correspondence)^{%- endif -%}
   <br>
-  {%- if author.orcid is defined and author.orcid is not none %}
+  {%- if author.orcid is defined and author.orcid is not none %} {% set line1 = true %}
     ![ORCID icon](images/orcid.svg){.inline_icon width=16 height=16}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
   {%- endif %}
-  {%- if author.github is defined and author.github is not none %}
+  {%- if author.github is defined and author.github is not none %} {% set line1 = true %}
     · ![GitHub icon](images/github.svg){.inline_icon width=16 height=16}
     [{{author.github}}](https://github.com/{{author.github}})
   {%- endif %}
-  {%- if author.twitter is defined and author.twitter is not none %}
+  {%- if author.twitter is defined and author.twitter is not none %} {% set line1 = true %}
     · ![Twitter icon](images/twitter.svg){.inline_icon width=16 height=16}
     [{{author.twitter}}](https://twitter.com/{{author.twitter}})
-  {%- endif %}<br>
+  {%- endif %}
+  {%- if line1 is defined and line1 == true %}
+    <br>
+  {%- endif %}
   <small>
   {%- if author.affiliations is defined and author.affiliations|length %}
      {{author.affiliations | join('; ')}}


### PR DESCRIPTION
This PR adds a small change in front-matter to fix the author list when no author metadata (ORCID, Github, Twitter, etc) is given for an author. Below, I show an example of the current code and problem in [this manuscript](https://greenelab.github.io/phenoplier_manuscript/):

![image](https://user-images.githubusercontent.com/172687/197235974-265db1f9-8ca8-4cf0-b926-6d1b40b87e97.png)

As you can see, when metadata is no present for an author, an unnecessary line break is added leaving an empty blank line.
This PR fixes this, producing this output:

![image](https://user-images.githubusercontent.com/172687/197236252-d07ea8ff-4be0-4054-99e9-c162b9f8585e.png)
