### PR TITLE
Add librsvg as dependency

### DIFF
--- a/build/environment.yml
+++ b/build/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - ghp-import=2.1.0
   - jinja2=3.1.2
   - jsonschema=4.17.0
+  - librsvg=2.52.5
   - pandoc=2.19.2
   - pango=1.48.10
   - pip=22.3.1

--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -186,6 +186,7 @@ Loaded from a specific (hashed) version of the image on GitHub.
 **A vector `.svg` image loaded from GitHub.**
 The parameter `sanitize=true` is necessary to properly load SVGs hosted via GitHub URLs.
 White background specified to serve as a backdrop for transparent sections of the image.
+Note that if you want to export to Word (`.docx`), you need to download the image and reference it locally (e.g. `content/images/vector.svg`) instead of using a URL.
 ](https://raw.githubusercontent.com/manubot/resources/main/test/vector.svg?sanitize=true "Vector image"){#fig:vector-image height=2.5in .white}
 
 ## Tables


### PR DESCRIPTION
This PR is related to issue #488. It adds `librsvg` as a dependency so pandoc converts SVG images to a format supported by Word (`.docx`).

I think this was not introduced here, but when I build the rootstock manuscript with `BUILD_DOCX=true`, opening the docx file with OpenOffice Writer shows this error:

![image](https://user-images.githubusercontent.com/172687/223223493-1d841476-7386-4586-abbc-85df6d602d4a.png)

Clicking on "yes" allows to open the document. However, the SVG file (`vector.svg`) is not shown in the Word document. This is fixed if the file is downloaded and referenced locally. I thought it might be important to mention how to do this in the documentation, so I also added a note about this.