### PR TITLE
Upgrade to pandoc 3

### DIFF
--- a/build/environment.yml
+++ b/build/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - jsonschema=4.17.0
   - pandoc=2.19.2
   - pango=1.48.10
-  - pip=22.3.1
+  - pip=23.0.1
   - python=3.11.0
   - requests-cache=0.9.6
   - requests=2.28.1
@@ -20,7 +20,7 @@ dependencies:
   - pip:
     - cffi==1.15.0
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@d4242ffa4194e4a13a68c5f6466feff559d3f9d5
+    - git+https://github.com/manubot/manubot@f62dd4cfdebf67f99f63c9b2e64edeaa591eeb69
     - isbnlib==3.10.10
     - opentimestamps-client==0.7.1
     - opentimestamps==0.4.3


### PR DESCRIPTION
Currently just a draft / stub PR since the conda-forge build for pandoc 3 is not out yet:

- https://github.com/conda-forge/pandoc-feedstock/pull/124

From the release notes:

> There is now a dedicate Figure block constructor for figures. The old hack of representing a figure as `Para [Image attr [..alt..] (source, "fig:title")]` has been dropped.

It's possible pandoc-fignos will break as pandoc-crossref made updates to support 3.0: https://github.com/lierdakil/pandoc-crossref/commit/e8e9546450e280992c71bbcba1161e4756b907e8. We also should make sure all of our javascript plugins still work.