### PR TITLE
Set write permissions in AI workflow

### DIFF
--- a/.github/workflows/ai-revision.yaml
+++ b/.github/workflows/ai-revision.yaml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     defaults:
       run:
         shell: bash --login {0}

--- a/.github/workflows/ai-revision.yaml
+++ b/.github/workflows/ai-revision.yaml
@@ -27,6 +27,8 @@ jobs:
   ai-revise:
     name: AI Revise
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash --login {0}


### PR DESCRIPTION
Closes #492

I'm not sure whether additional changes are needed for the draft pull request issue once write permissions are enabled. Line 68 already sets `draft: true`.