### PR TITLE
Fix typo in table ref for 02.delete-me.md

### DIFF
--- a/content/02.delete-me.md
+++ b/content/02.delete-me.md
@@ -215,7 +215,7 @@ Table: A table too wide to fit within page.
 | small    | black                            | white                |
 
 Table: A table with merged cells using the `attributes` plugin.
-{#tbl: merged-cells}
+{#tbl:merged-cells}
 
 ## Equations
 


### PR DESCRIPTION
Space between #tbl: and name is not supported

I don't know if it would be worth adding a tip not to try to bold the Table name because I've been struggling with broken table refs for about thirty minutes and it turned out that was my mistake!