### PR TITLE
CI: appveyor use ubuntu 22.04

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ only_commits:
     - ci/install.sh
     - content/
 
-image: ubuntu
+image: ubuntu2204
 services:
   - docker
 


### PR DESCRIPTION
refs https://github.com/manubot/rootstock/issues/508