### PR TITLE
AI-revision: change default model to GPT 3.5 Turbo

### DIFF
--- a/.github/workflows/ai-revision.yaml
+++ b/.github/workflows/ai-revision.yaml
@@ -16,7 +16,7 @@ on:
         description: 'Language model'
         required: true
         type: string
-        default: 'text-davinci-003'
+        default: 'gpt-3.5-turbo'
       custom_prompt:
         description: 'Custom prompt'
         required: false
@@ -26,7 +26,7 @@ on:
         description: 'Output branch'
         required: true
         type: string
-        default: 'ai-revision-davinci'
+        default: 'ai-revision-gpt35'
 
 jobs:
   ai-revise:


### PR DESCRIPTION
This PR simply updated the LLM to `gpt-3.5-turbo` since `text-davinci-003` is now deprecated.