### PR TITLE
Remove explicitly set `mamba`-stuff from workflow file

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -84,9 +84,6 @@ jobs:
           activate-environment: manubot
           environment-file: build/environment.yml
           auto-activate-base: false
-          miniforge-variant: Mambaforge
-          miniforge-version: 'latest'
-          use-mamba: true
       - name: Install Spellcheck
         if: env.SPELLCHECK == 'true'
         run: bash ci/install-spellcheck.sh


### PR DESCRIPTION
Removing the explicitly set `Mambaforge` variant and the call to `use-mamba` took care of an error preventing GitHub Actions to build a manuscript of mine during the so-called 'brownout days' stated in https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

I might not see all the consequences of simply deleting those details, but submit this nonetheless as a PR :)

Fixes #519 