### PR TITLE
Updates ai-revision workflow for upcoming manubot-ai-editor multi-provider feature

### DIFF
--- a/.github/workflows/ai-revision.yaml
+++ b/.github/workflows/ai-revision.yaml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ''
+      model_provider:
+        description: 'Model Provider'
+        required: true
+        type: string
+        default: 'openai'
+      model_provider_email:
+        description: 'Model Provider Author Email'
+        required: true
+        type: string
+        default: '<support@openai.com>'
       model:
         description: 'Language model'
         required: true
@@ -56,7 +66,8 @@ jobs:
           pip install ${manubot_url}#egg=manubot[ai-rev]
       - name: Revise manuscript
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PROVIDER_API_KEY: ${{ secrets.PROVIDER_API_KEY || secrets.OPENAI_API_KEY }}
+          AI_EDITOR_MODEL_PROVIDER: ${{ inputs.model_provider }}
           AI_EDITOR_LANGUAGE_MODEL: ${{ inputs.model }}
           AI_EDITOR_FILENAMES_TO_REVISE: ${{ inputs.file_names }}
           AI_EDITOR_CUSTOM_PROMPT: ${{ inputs.custom_prompt }}
@@ -66,9 +77,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: 'revise using AI model\n\nUsing the OpenAI model ${{ inputs.model }}'
+          commit-message: 'revise using AI model\n\nUsing the ${{ inputs.model_provider }} model ${{ inputs.model }}'
           title: 'AI-based revision using ${{ inputs.model }}'
-          author: OpenAI model ${{ inputs.model }} <support@openai.com>
+          author: ${{ inputs.model_provider }} model ${{ inputs.model }} ${{ inputs.model_provider_email }}
           add-paths: |
             content/*.md
           branch: ${{ inputs.branch_name }}

--- a/.github/workflows/ai-revision.yaml
+++ b/.github/workflows/ai-revision.yaml
@@ -13,20 +13,15 @@ on:
         type: string
         default: ''
       model_provider:
-        description: 'Model Provider'
+        description: 'Model Provider (one of "openai", "anthropic")'
         required: true
         type: string
         default: 'openai'
-      model_provider_email:
-        description: 'Model Provider Author Email'
-        required: true
-        type: string
-        default: '<support@openai.com>'
       model:
         description: 'Language model'
         required: true
         type: string
-        default: 'gpt-4-turbo'
+        default: 'gpt-4o'
       custom_prompt:
         description: 'Custom prompt'
         required: false
@@ -79,7 +74,7 @@ jobs:
         with:
           commit-message: 'revise using AI model\n\nUsing the ${{ inputs.model_provider }} model ${{ inputs.model }}'
           title: 'AI-based revision using ${{ inputs.model }}'
-          author: ${{ inputs.model_provider }} model ${{ inputs.model }} ${{ inputs.model_provider_email }}
+          author: ${{ inputs.model_provider }} model ${{ inputs.model }} <support@${{ inputs.model_provider }}.com>
           add-paths: |
             content/*.md
           branch: ${{ inputs.branch_name }}


### PR DESCRIPTION
We'll shortly be introducing the ability for `manubot-ai-editor` to work with multiple providers (e.g., OpenAI, Anthropic, and more), facilitated by the [LangChain](https://python.langchain.com/docs/introduction/) library. These changes are included in PR manubot/manubot-ai-editor#71. That PR should be merged and a release created before we merge this PR, so this PR will remain a draft until that's completed.

Since we'll potentially be implementing many providers, we decided to allow a generic environment variable, `PROVIDER_API_KEY`, to specify the API key used for any one provider. While `manubot-ai-editor` could theoretically be run with multiple providers (each of which would need their own valid API key, of course), this particular workflow always runs the revision process with a single specific provider, so I assumed that using `PROVIDER_API_KEY` would be sufficient here. To not break things during the transition, the value will also be retrieved from `secrets.OPENAI_API_KEY` if `secrets.PROVIDER_API_KEY` is unavailable; this will likely be removed down the road.

I've also added `model_provider` to the inputs to specify the model provider (i.e., "openai" or "anthropic" for now). I'm unsure if we should provide the list of options as a dropdown and just update this whenever we add new providers, or keep it as a free-text string. I've included the list of providers we currently support for now, but I'm considering removing that in favor of either having a set list of options that we update, or directing the user to the manubot-ai-editor docs for an up-to-date list.

Finally, on @miltondp's advice, the default model engine is now `gpt-4o` rather than `gpt-4-turbo`.